### PR TITLE
Use lightweight copies of Chakra's <Td /> and <Radio />

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1772,6 +1772,32 @@
         "stylis": "^4.0.3"
       }
     },
+    "@emotion/css": {
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.1.3.tgz",
+      "integrity": "sha512-RSQP59qtCNTf5NWD6xM08xsQdCZmVYnX/panPYvB6LQAPKQB6GL49Njf0EMbS3CyDtrlWsBcmqBtysFvfWT3rA==",
+      "requires": {
+        "@emotion/babel-plugin": "^11.0.0",
+        "@emotion/cache": "^11.1.3",
+        "@emotion/serialize": "^1.0.0",
+        "@emotion/sheet": "^1.0.0",
+        "@emotion/utils": "^1.0.0"
+      },
+      "dependencies": {
+        "@emotion/cache": {
+          "version": "11.1.3",
+          "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.1.3.tgz",
+          "integrity": "sha512-n4OWinUPJVaP6fXxWZD9OUeQ0lY7DvtmtSuqtRWT0Ofo/sBLCVSgb4/Oa0Q5eFxcwablRKjUXqXtNZVyEwCAuA==",
+          "requires": {
+            "@emotion/memoize": "^0.7.4",
+            "@emotion/sheet": "^1.0.0",
+            "@emotion/utils": "^1.0.0",
+            "@emotion/weak-memoize": "^0.2.5",
+            "stylis": "^4.0.3"
+          }
+        }
+      }
+    },
     "@emotion/hash": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
@@ -13294,6 +13320,14 @@
         "react-clientside-effect": "^1.2.2",
         "use-callback-ref": "^1.2.1",
         "use-sidecar": "^1.0.1"
+      }
+    },
+    "react-hashchange": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/react-hashchange/-/react-hashchange-0.1.0.tgz",
+      "integrity": "sha512-RWBECpNMGfkIJW7d8NPvfCLeAQTOMWnrcjVLXnr8tsWFuBSSrZU3/En5zOYkiEIZNS+1M65tA6B1+XTERNy+kA==",
+      "requires": {
+        "prop-types": "^15.5.10"
       }
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@chakra-ui/icons": "^1.0.2",
     "@chakra-ui/react": "^1.1.0",
+    "@emotion/css": "^11.1.3",
     "@emotion/react": "^11.1.2",
     "@emotion/styled": "^11.0.0",
     "@testing-library/jest-dom": "^5.11.6",

--- a/src/app/TheTable.js
+++ b/src/app/TheTable.js
@@ -83,6 +83,11 @@ const BrainIcon = (props) => (
     </svg>
 )
 
+// A low-feature, high-performance copy of <Td /> from @chakra-ui/react.
+// We render a few hundred cells in the table, so it's important that they render very fast!
+//
+// NOTE(matchu): To build this, I manually inspected <Td />'s behavior on the page, and
+//               copied the relevant HTML and styles here by hand!
 const Td = (props) => {
     const {backgroundColor, colSpan, isNumeric, rowSpan, px, style, whiteSpace, zIndex} = props;
 
@@ -119,6 +124,80 @@ const Td = (props) => {
 
 // A special Td with minimal x-axis padding to cut down on giant tables
 const Pd = (props) => (<Td px={1} {...props}>{props.children}</Td>);
+
+// A low-feature, high-performance copy of <Radio /> from @chakra-ui/react.
+// We render a few hundred radios in the table, so it's important that they render very fast!
+//
+// NOTE(matchu): To build this, I manually inspected <Radio />'s behavior on the page, and
+//               copied the relevant HTML and styles here by hand!
+const TableRadio = (props) => {
+    const {name, value, isChecked, onChange} = props;
+
+    return (
+        <label
+            className={css`
+                display: inline-flex;
+                align-items: center;
+                vertical-align: top;
+            `}
+        >
+            <input
+                type="radio"
+                name={name}
+                value={value}
+                checked={isChecked}
+                onChange={onChange}
+                className={css`
+                    border: 0px none;
+                    clip: rect(0px, 0px, 0px, 0px);
+                    height: 1px;
+                    width: 1px;
+                    margin: -1px;
+                    padding: 0px;
+                    overflow: hidden;
+                    white-space: nowrap;
+                    position: absolute;
+                `}
+            />
+            <div
+                aria-hidden="true"
+                className={css`
+                    display: inline-flex;
+                    align-items: center;
+                    justify-content: center;
+                    flex-shrink: 0;
+                    width: 1rem;
+                    transition: box-shadow 250ms;
+                    border: 2px solid;
+                    border-color: inherit;
+                    border-radius: 9999px;
+                    color: white;
+                    height: 1rem;
+
+                    input[type=radio]:focus + & {
+                        box-shadow: rgba(66, 153, 225, 0.6) 0px 0px 0px 3px;
+                    }
+
+                    input[type=radio]:checked + & {
+                        background: #3182CE; /* blue.500 */
+                        border-color: #3182CE; /* blue.500 */
+                        color: white;
+
+                        &::before {
+                            content: "";
+                            display: inline-block;
+                            position: relative;
+                            width: 50%;
+                            height: 50%;
+                            border-radius: 50%;
+                            background: currentcolor;
+                        }
+                    }
+                `}
+            />
+        </label>
+    );
+};
 
 const TextTooltip = (props) => {
     const {text, label, ...rest} = props;
@@ -395,7 +474,7 @@ const NormalTable = (props) => {
                                     {[...Array(amountOfBets)].map((bet, betNum) => {
                                         return (
                                             <Td key={betNum} backgroundColor={grayAccent}>
-                                                <Radio
+                                                <TableRadio
                                                     name={"bet" + (betNum + 1) + arenaId}
                                                     value={0}
                                                     onChange={() => changeBet(betNum + 1, arenaId, 0)}
@@ -499,7 +578,7 @@ const NormalTable = (props) => {
                                         {[...Array(amountOfBets)].map((bet, betNum) => {
                                             return (
                                                 <Td key={betNum}>
-                                                    <Radio name={"bet" + (betNum + 1) + arenaId}
+                                                    <TableRadio name={"bet" + (betNum + 1) + arenaId}
                                                            value={pirateIndex + 1}
                                                            onChange={() => changeBet(betNum + 1, arenaId, pirateIndex + 1)}
                                                            isChecked={roundState.bets[betNum + 1][arenaId] === pirateIndex + 1}/>

--- a/src/app/TheTable.js
+++ b/src/app/TheTable.js
@@ -16,7 +16,6 @@ import {
     StatArrow,
     Table,
     Tbody,
-    Td as OriginalTd,
     Text,
     Th,
     Thead,
@@ -29,6 +28,7 @@ import {
 } from "@chakra-ui/react";
 import {ArrowDownIcon, ArrowUpIcon, LinkIcon} from "@chakra-ui/icons";
 import React, {useEffect, useState} from "react";
+import {css} from "@emotion/css";
 import RoundContext from "./RoundState";
 import {
     calculateArenaRatios,
@@ -83,7 +83,39 @@ const BrainIcon = (props) => (
     </svg>
 )
 
-const Td = (props) => (<OriginalTd py={1} {...props}>{props.children}</OriginalTd>);
+const Td = (props) => {
+    const {backgroundColor, colSpan, isNumeric, rowSpan, px, style, whiteSpace, zIndex} = props;
+
+    return (
+        <td
+            colSpan={colSpan}
+            rowSpan={rowSpan}
+            className={css(
+                css`
+                    text-align: left;
+                    padding: 0.25rem 1rem;
+                    font-size: 0.875rem;
+                    line-height: 1rem;
+                    border-bottom: 1px solid #EDF2F7;
+                `,
+                px == 1 && css`
+                    padding: 0.25rem;
+                `,
+                isNumeric && css`
+                    text-align: right;
+                `
+            )}
+            style={{
+                ...style,
+                backgroundColor,
+                whiteSpace,
+                zIndex,
+            }}
+        >
+            {props.children}
+        </td>
+    );
+};
 
 // A special Td with minimal x-axis padding to cut down on giant tables
 const Pd = (props) => (<Td px={1} {...props}>{props.children}</Td>);

--- a/src/app/TheTable.js
+++ b/src/app/TheTable.js
@@ -28,7 +28,7 @@ import {
 } from "@chakra-ui/react";
 import {ArrowDownIcon, ArrowUpIcon, LinkIcon} from "@chakra-ui/icons";
 import React, {useEffect, useState} from "react";
-import {css} from "@emotion/css";
+import {css, cx} from "@emotion/css";
 import RoundContext from "./RoundState";
 import {
     calculateArenaRatios,
@@ -89,13 +89,13 @@ const BrainIcon = (props) => (
 // NOTE(matchu): To build this, I manually inspected <Td />'s behavior on the page, and
 //               copied the relevant HTML and styles here by hand!
 const Td = (props) => {
-    const {backgroundColor, colSpan, isNumeric, rowSpan, px, style, whiteSpace, zIndex} = props;
+    const {backgroundColor, className, colSpan, isNumeric, rowSpan, px, style, whiteSpace, zIndex} = props;
 
     return (
         <td
             colSpan={colSpan}
             rowSpan={rowSpan}
-            className={css(
+            className={cx(className, css(
                 css`
                     text-align: left;
                     padding: 0.25rem 1rem;
@@ -109,7 +109,7 @@ const Td = (props) => {
                 isNumeric && css`
                     text-align: right;
                 `
-            )}
+            ))}
             style={{
                 ...style,
                 backgroundColor,


### PR DESCRIPTION
One of the main performance bottlenecks on the big table page is simply that Chakra UI elements are... kinda slow when you render hundreds at a time.

There's not really a direct way to fix this; it's built into the core of their styling system. Here's the benchmarking app we used to test the APIs available to us: https://style-benchmarking.vercel.app/

So here, I fix this by using `@emotion/css`, which runs at speeds similar to native CSS classes. I'm surprised that their other APIs like `@emotion/styled` have so much overhead, even when used for simple styles! But `@emotion/css` supports very few features, and I guess that helps it be way faster :)

I'm not thrilled about pulling these styles out manually... it means that adding new styles to these elements will be a bit of work, and that they'll be out of sync with Chakra theming and Chakra updates. But the perf win seems super important for this page, so I think the right call is to eat that maintenance cost!
