### PR TITLE
Fix mobile scroll bug

### DIFF
--- a/src/app/TheTable.js
+++ b/src/app/TheTable.js
@@ -770,7 +770,19 @@ const PayoutTable = (props) => {
 
 const HorizontalScrollingBox = (props) => {
     const {children, ...rest} = props;
-    return (<Box overflowX="auto" {...rest}>{children}</Box>);
+    return (
+        <Box
+            overflowX="auto"
+            // Prevent position:absolute elements from escaping. Without this, elements
+            // scrolled out of view will become absolutely-positioned relative to the
+            // *page*, and extend the entire page's scroll area to fit them. This includes
+            // normal hidden elements, like in Chakra's <Radio />!
+            position="relative"
+            {...rest}
+        >
+            {children}
+        </Box>
+    );
 }
 
 const PlaceThisBetButton = (props) => {


### PR DESCRIPTION
The culprit was Chakra's `<Radio />`!

I figured this out by sorta a bisect approach? I started deleting elements from the page until I discovered that it was the pirates table causing the problem, and then I started commenting out elements from the table source code until I discovered that the radios were the culprit.

And then I asked myself: "okay how do we fix this again? Right, by not letting them out."