### PR TITLE
Remove redraw prop from payout chart Scatter component

### DIFF
--- a/src/app/components/charts/PayoutCharts.tsx
+++ b/src/app/components/charts/PayoutCharts.tsx
@@ -288,7 +288,7 @@ const PayoutCharts: React.FC = React.memo(() => {
           <Table.Cell colSpan={4} pt={2} borderBottom="none" w="full">
             <Box w="full" h={{ base: '160px', md: '180px' }}>
               {/* @ts-ignore */}
-              <Scatter data={chartData} options={options} redraw />
+              <Scatter data={chartData} options={options} />
             </Box>
           </Table.Cell>
         </Table.Row>


### PR DESCRIPTION
## Summary
- The payout charts (`PayoutCharts.tsx`) render sometimes very wide until a later re-render corrects them.
- react-chartjs-2's `redraw` prop is documented to fully teardown and recreate the Chart.js instance on every `data`/`options` update, instead of the normal incremental `chart.update()`. Since `chartData`/`options` are rebuilt fresh on every store update (calculations streaming in) or color-mode toggle, this meant the chart was being destroyed and recreated far more often than necessary, and each recreation re-measures its container from scratch - a needless source of measurement races.
- Removing `redraw` lets react-chartjs-2 update the existing chart in place, which is sufficient here (single dataset, no separate `label` key needed for the merge).

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Manually verify in a running app: load a round, generate a bet set, toggle theme (Light/Dark/Night), and resize across the `lg` breakpoint - confirm the payout charts render at the correct width and never appear stretched