### PR TITLE
Restore consistent table cell padding lost in Chakra v3 migration

### DIFF
--- a/src/app/components/tables/ArenaTableBody.tsx
+++ b/src/app/components/tables/ArenaTableBody.tsx
@@ -125,7 +125,7 @@ const StickyTd = React.memo(
       ...filteredRest,
     };
 
-    return <Table.Cell {...tdProps}>{children}</Table.Cell>;
+    return <Td {...tdProps}>{children}</Td>;
   },
 );
 
@@ -285,7 +285,7 @@ const EmptyBetsPlaceholder = React.memo(() => (
 EmptyBetsPlaceholder.displayName = 'EmptyBetsPlaceholder';
 
 const EmptyTd = React.memo((props: { colSpan?: number }) => (
-  <Table.Cell backgroundColor="bg.subtle" colSpan={props.colSpan || 1} />
+  <Td backgroundColor="bg.subtle" colSpan={props.colSpan || 1} />
 ));
 
 const ArenaHeaderRow = React.memo(
@@ -343,7 +343,7 @@ const ArenaHeaderRow = React.memo(
 
     return (
       <Table.Row>
-        <Table.Cell
+        <Td
           rowSpan={5}
           backgroundColor="bg.subtle"
           cursor="pointer"
@@ -352,11 +352,11 @@ const ArenaHeaderRow = React.memo(
           _hover={{ bg: 'bg.emphasized' }}
         >
           <Text fontWeight="bold">{ARENA_NAMES[arenaId]}</Text>
-        </Table.Cell>
+        </Td>
         {bigBrain && (
-          <Table.Cell rowSpan={5} backgroundColor="bg.subtle" textAlign="center">
+          <Td rowSpan={5} backgroundColor="bg.subtle" textAlign="center">
             <ArenaRatioDisplay arenaId={arenaId} />
-          </Table.Cell>
+          </Td>
         )}
         <EmptyTd colSpan={emptyColSpan} />
         {faDetails ? <FoodItems arenaId={arenaId} /> : null}
@@ -534,12 +534,12 @@ const PirateRow = React.memo(
       }
 
       return (
-        <Table.Cell
+        <Td
           textAlign="end"
           {...(pirateWon && { layerStyle: 'fill.subtle', colorPalette: 'nfc-green' })}
         >
           {displayAsPercent(logitProb, 1)}
-        </Table.Cell>
+        </Td>
       );
     }, [logitProb, useLogitModel, bigBrain, pirateWon]);
 
@@ -549,12 +549,12 @@ const PirateRow = React.memo(
       }
 
       return (
-        <Table.Cell
+        <Td
           textAlign="end"
           {...(pirateWon && { layerStyle: 'fill.subtle', colorPalette: 'nfc-green' })}
         >
           {pirateFA}
-        </Table.Cell>
+        </Td>
       );
     }, [pirateFA, bigBrain, pirateWon]);
 
@@ -569,24 +569,24 @@ const PirateRow = React.memo(
 
       return (
         <>
-          <Table.Cell
+          <Td
             textAlign="end"
             {...(pirateWon && { layerStyle: 'fill.subtle', colorPalette: 'nfc-green' })}
           >
             {displayAsPercent(legacyProbMin, 1)}
-          </Table.Cell>
-          <Table.Cell
+          </Td>
+          <Td
             textAlign="end"
             {...(pirateWon && { layerStyle: 'fill.subtle', colorPalette: 'nfc-green' })}
           >
             {displayAsPercent(legacyProbMax, 1)}
-          </Table.Cell>
-          <Table.Cell
+          </Td>
+          <Td
             textAlign="end"
             {...(pirateWon && { layerStyle: 'fill.subtle', colorPalette: 'nfc-green' })}
           >
             {displayAsPercent(legacyProbStd, 1)}
-          </Table.Cell>
+          </Td>
         </>
       );
     }, [legacyProbMin, legacyProbMax, legacyProbStd, useLogitModel, bigBrain, pirateWon]);
@@ -673,12 +673,12 @@ const PirateRow = React.memo(
       }
 
       return (
-        <Table.Cell
+        <Td
           textAlign="end"
           {...(payoutBackground && { layerStyle: 'fill.subtle', colorPalette: payoutBackground })}
         >
           {displayAsPercent(payout, 1)}
-        </Table.Cell>
+        </Td>
       );
     }, [payout, payoutBackground, bigBrain]);
 
@@ -690,9 +690,9 @@ const PirateRow = React.memo(
     if (!pirateId) {
       return (
         <Table.Row>
-          <Table.Cell colSpan={100}>
+          <Td colSpan={100}>
             <Skeleton height="24px">&nbsp;</Skeleton>
-          </Table.Cell>
+          </Td>
         </Table.Row>
       );
     }
@@ -719,13 +719,13 @@ const PirateRow = React.memo(
         {payoutElement}
         {faElement}
         {faDetailsElement}
-        <Table.Cell
+        <Td
           textAlign="end"
           {...(pirateWon && { layerStyle: 'fill.subtle', colorPalette: 'nfc-green' })}
         >
           {openingOdds}:1
-        </Table.Cell>
-        <Table.Cell
+        </Td>
+        <Td
           textAlign="end"
           whiteSpace="nowrap"
           {...(pirateWon && { layerStyle: 'fill.subtle', colorPalette: 'nfc-green' })}
@@ -738,11 +738,11 @@ const PirateRow = React.memo(
             )}
             <Text fontWeight={oddsChanged ? 'bold' : 'normal'}>{currentOdds}:1</Text>
           </Box>
-        </Table.Cell>
+        </Td>
         {customOddsInputElement}
         {timelineElement}
         {betRadios}
-        <Table.Cell whiteSpace="nowrap">
+        <Td whiteSpace="nowrap">
           <Box display="flex" gap={1} justifyContent="center">
             <Tooltip content="10-bet" openDelay={600} placement="top">
               <IconButton
@@ -853,7 +853,7 @@ const PirateRow = React.memo(
               </Portal>
             </Popover.Root>
           </Box>
-        </Table.Cell>
+        </Td>
       </Table.Row>
     );
   },

--- a/src/app/components/tables/PayoutTable.tsx
+++ b/src/app/components/tables/PayoutTable.tsx
@@ -136,7 +136,7 @@ const PirateNameCell = React.memo(
     }, [hasModifications, hasCustomOdds, hasCustomProbs]);
 
     return (
-      <Table.Cell {...(bgColor && { layerStyle: 'fill.subtle', colorPalette: bgColor })}>
+      <Td {...(bgColor && { layerStyle: 'fill.subtle', colorPalette: bgColor })}>
         <HStack gap={1} display="inline-flex" alignItems="center">
           <Text>{pirateName}</Text>
           {hasModifications && (
@@ -154,7 +154,7 @@ const PirateNameCell = React.memo(
             </Tooltip>
           )}
         </HStack>
-      </Table.Cell>
+      </Td>
     );
   },
 );
@@ -297,15 +297,15 @@ const PayoutTableRow = React.memo(
             {...(baBg && { errorColor: baBg })}
           />
         </Td>
-        <Table.Cell style={{ textAlign: 'end' }}>
+        <Td style={{ textAlign: 'end' }}>
           {odds?.toLocaleString() ?? '0'}
           :1
-        </Table.Cell>
-        <Table.Cell style={{ textAlign: 'end' }}>{payoffs?.toLocaleString() ?? '0'}</Table.Cell>
-        <Table.Cell style={{ textAlign: 'end' }}>
+        </Td>
+        <Td style={{ textAlign: 'end' }}>{payoffs?.toLocaleString() ?? '0'}</Td>
+        <Td style={{ textAlign: 'end' }}>
           <MemoizedTextTooltip text={probabilityTooltip.text} content={probabilityTooltip.label} />
-        </Table.Cell>
-        <Table.Cell
+        </Td>
+        <Td
           style={{ textAlign: 'end' }}
           {...(erBg && { layerStyle: 'fill.subtle', colorPalette: erBg })}
         >
@@ -313,14 +313,14 @@ const PayoutTableRow = React.memo(
             text={expectedRatioTooltip.text}
             content={expectedRatioTooltip.label}
           />
-        </Table.Cell>
-        <Table.Cell
+        </Td>
+        <Td
           style={{ textAlign: 'end' }}
           {...(neBg && { layerStyle: 'fill.subtle', colorPalette: neBg })}
         >
           <MemoizedTextTooltip text={netExpectedTooltip.text} content={netExpectedTooltip.label} />
-        </Table.Cell>
-        <Table.Cell
+        </Td>
+        <Td
           style={{ textAlign: 'end' }}
           {...(mbBg && { layerStyle: 'fill.subtle', colorPalette: mbBg })}
         >
@@ -339,7 +339,7 @@ const PayoutTableRow = React.memo(
           ) : (
             (maxBets?.toLocaleString() ?? '0')
           )}
-        </Table.Cell>
+        </Td>
         {[0, 1, 2, 3, 4].map(arenaIndex => {
           const pirateIndex = currentBetLine[arenaIndex] as number;
           return (
@@ -350,9 +350,9 @@ const PayoutTableRow = React.memo(
             />
           );
         })}
-        <Table.Cell {...stickySubmitColumnProps}>
+        <Td {...stickySubmitColumnProps}>
           <PlaceThisBetButton bet={currentBetLine} betNum={betIndex + 1} />
-        </Table.Cell>
+        </Td>
       </Table.Row>
     );
   },

--- a/src/app/components/tables/Td.tsx
+++ b/src/app/components/tables/Td.tsx
@@ -3,7 +3,9 @@ import { Table } from '@chakra-ui/react';
 // this element is a chakra <Td> but with less y-padding, to make our tables a little less large
 
 const Td = (props: React.ComponentProps<typeof Table.Cell>): React.ReactElement => (
-  <Table.Cell {...props}>{props.children}</Table.Cell>
+  <Table.Cell py={1} {...props}>
+    {props.children}
+  </Table.Cell>
 );
 
 export default Td;


### PR DESCRIPTION
## Summary
- The shared `Td` wrapper (`src/app/components/tables/Td.tsx`) lost its `py={1}` override during the Chakra v2 -> v3 migration, even though the comment describing that reduced padding stayed in place.
- Several body cells in `PayoutTable.tsx` and `ArenaTableBody.tsx` were also left on raw `Table.Cell` instead of the shared `Td`, so cells within the same row ended up with mismatched heights.
- Restores `py={1}` on `Td` and routes all remaining plain data-body cells through it, matching the pre-migration behavior where every table cell went through the same wrapper.

## Test plan
- [x] `npm run typecheck` passes (one pre-existing, unrelated error in `AllBetsModal.tsx` also present on `master` before this change)
- [x] Verified visually with a headless-browser screenshot of a live round: arena table and generated payout table both show uniform row heights across all cells