### PR TITLE
Show the odds timeline bar inside the pirate timeline drawer

### DIFF
--- a/src/app/components/timeline/OddsTimeline.tsx
+++ b/src/app/components/timeline/OddsTimeline.tsx
@@ -1,6 +1,7 @@
 import { Box, Table } from '@chakra-ui/react';
 import React, { useMemo } from 'react';
 
+import { RoundData } from '../../../types';
 import { useRoundStore } from '../../stores';
 import { getOrdinalSuffix, filterChangesByArenaPirate } from '../../utils/betUtils';
 
@@ -33,6 +34,62 @@ function calculatePercentages(timestamps: number[], endTime: number): number[] {
   });
 
   return percentages;
+}
+
+/**
+ * Build the odds-history segments (opening odds -> each change -> current) for a single
+ * pirate, with each segment's proportional width across the round's duration so far.
+ * Shared by the table-cell bar (OddsTimeline) and the timeline drawer's pirate view.
+ */
+export function buildOddsTimelineSegments(
+  roundData: RoundData,
+  arenaId: number,
+  pirateIndex: number,
+): OddsTimelineSegment[] {
+  const openingOdds = roundData?.openingOdds?.[arenaId]?.[pirateIndex + 1];
+  const start = roundData?.start;
+
+  if (!openingOdds || !start) {
+    return [];
+  }
+
+  const startDate = new Date(start);
+  const startTime = startDate.getTime();
+  const changes = roundData.changes || [];
+
+  // Build odds history: opening -> changes -> current
+  const odds: number[] = [openingOdds];
+  const times: number[] = [startTime];
+
+  const pirateChanges = filterChangesByArenaPirate(changes, arenaId, pirateIndex);
+  pirateChanges.forEach(change => {
+    const lastOdds = odds[odds.length - 1];
+    if (change.new !== lastOdds) {
+      odds.push(change.new);
+      times.push(new Date(change.t).getTime());
+    }
+  });
+
+  // Determine end time for the timeline
+  let endTime: number;
+  if (pirateChanges.length > 0) {
+    // This pirate has had changes, use timestamp as end
+    endTime = new Date(roundData.timestamp as string).getTime();
+  } else if (roundData.lastChange) {
+    // No changes for this pirate, but round has changes - use lastChange
+    endTime = new Date(roundData.lastChange).getTime();
+  } else {
+    // Brand new round, no changes at all - use start time
+    endTime = startTime;
+  }
+
+  const percentages = calculatePercentages(times, endTime);
+
+  return odds.map((thisOdds, i) => ({
+    odds: thisOdds,
+    percent: percentages[i] ?? 0,
+    timestamp: times[i] ?? 0,
+  }));
 }
 
 /**
@@ -104,10 +161,18 @@ interface OddsTimelineBarsProps {
   segments: OddsTimelineSegment[];
   onClick?: () => void;
   readOnly?: boolean;
+  ariaLabel?: string;
 }
 
 export const OddsTimelineBars = React.memo((props: OddsTimelineBarsProps): React.ReactElement => {
-  const { arenaId, pirateIndex, segments, onClick, readOnly = false } = props;
+  const {
+    arenaId,
+    pirateIndex,
+    segments,
+    onClick,
+    readOnly = false,
+    ariaLabel = 'Example odds timeline',
+  } = props;
 
   return (
     <Box
@@ -123,7 +188,7 @@ export const OddsTimelineBars = React.memo((props: OddsTimelineBarsProps): React
       border="1px solid"
       borderColor="border"
       role={readOnly ? 'img' : undefined}
-      aria-label={readOnly ? 'Example odds timeline' : undefined}
+      aria-label={readOnly ? ariaLabel : undefined}
       css={readOnly ? { '& *': { cursor: 'default' } } : undefined}
     >
       {segments.map((segment, i) => (
@@ -157,66 +222,15 @@ const OddsTimeline = React.memo(
     const roundData = useRoundStore(state => state.roundData);
     const openingOdds = roundData?.openingOdds?.[arenaId]?.[pirateIndex + 1];
     const start = roundData?.start;
-    const lastChange = roundData?.lastChange;
-    const timestamp = roundData?.timestamp;
 
-    // Calculate timeline data
-    const startDate = useMemo(() => new Date(start as string), [start]);
-    const changes = useMemo(() => roundData.changes || [], [roundData.changes]);
-
-    // Get pirate odds history
-    const timelineData = useMemo(() => {
-      // Build odds history: opening → changes → current
-      const odds: number[] = [];
-      const times: number[] = [];
-
-      // Start with opening odds
-      if (!openingOdds) {
-        return { odds: [], percentages: [], times: [] };
-      }
-
-      // Start with opening odds
-      odds.push(openingOdds);
-      times.push(startDate.getTime());
-
-      // Add all changes for this pirate
-      const pirateChanges = filterChangesByArenaPirate(changes, arenaId, pirateIndex);
-      pirateChanges.forEach(change => {
-        const lastOdds = odds[odds.length - 1];
-        if (change.new !== lastOdds) {
-          odds.push(change.new);
-          times.push(new Date(change.t).getTime());
-        }
-      });
-
-      // Determine end time for the timeline
-      let endTime: number;
-      if (pirateChanges.length > 0) {
-        // This pirate has had changes, use timestamp as end
-        endTime = new Date(timestamp as string).getTime();
-      } else if (lastChange) {
-        // No changes for this pirate, but round has changes - use lastChange
-        endTime = new Date(lastChange).getTime();
-      } else {
-        // Brand new round, no changes at all - use start time
-        endTime = startDate.getTime();
-      }
-
-      // Calculate width percentages
-      const percentages = calculatePercentages(times, endTime);
-
-      return { odds, percentages, times };
-    }, [openingOdds, startDate, changes, arenaId, pirateIndex, lastChange, timestamp]);
+    const segments = useMemo(
+      () => buildOddsTimelineSegments(roundData, arenaId, pirateIndex),
+      [roundData, arenaId, pirateIndex],
+    );
 
     if (!openingOdds || !start) {
       return <Box>&nbsp;</Box>;
     }
-
-    const segments: OddsTimelineSegment[] = timelineData.odds.map((odds, i) => ({
-      odds,
-      percent: timelineData.percentages[i] ?? 0,
-      timestamp: timelineData.times[i] ?? 0,
-    }));
 
     return (
       <Table.Cell p={0}>

--- a/src/app/components/timeline/OddsTimeline.tsx
+++ b/src/app/components/timeline/OddsTimeline.tsx
@@ -101,8 +101,9 @@ const TimelineBar = React.memo(
     odds: number;
     percent: number;
     timestamp: number;
+    size?: 'sm' | 'lg';
   }): React.ReactElement => {
-    const { index, odds, percent, timestamp } = props;
+    const { index, odds, percent, timestamp, size = 'sm' } = props;
 
     const palettes = [
       'nfc-cyan',
@@ -128,12 +129,12 @@ const TimelineBar = React.memo(
           width={`${percent}%`}
           whiteSpace="nowrap"
           overflow="hidden"
-          fontSize="xs"
+          fontSize={size === 'lg' ? 'sm' : 'xs'}
           layerStyle="fill.muted"
           colorPalette={palettes[odds % (palettes.length - 1)]}
           fontWeight="semibold"
           textAlign="center"
-          minH="6"
+          minH={size === 'lg' ? '9' : '6'}
           display="flex"
           alignItems="center"
           justifyContent="center"
@@ -162,6 +163,8 @@ interface OddsTimelineBarsProps {
   onClick?: () => void;
   readOnly?: boolean;
   ariaLabel?: string;
+  maxW?: string;
+  size?: 'sm' | 'lg';
 }
 
 export const OddsTimelineBars = React.memo((props: OddsTimelineBarsProps): React.ReactElement => {
@@ -172,19 +175,19 @@ export const OddsTimelineBars = React.memo((props: OddsTimelineBarsProps): React
     onClick,
     readOnly = false,
     ariaLabel = 'Example odds timeline',
+    maxW = '300px',
+    size = 'sm',
   } = props;
 
   return (
     <Box
-      maxW="300px"
+      maxW={maxW}
       onClick={readOnly ? undefined : onClick}
       cursor={readOnly ? 'default' : 'pointer'}
-      pointerEvents={readOnly ? 'none' : undefined}
       display="flex"
       px="0"
-      rounded="lg"
       overflow="hidden"
-      borderRadius="md"
+      borderRadius="lg"
       border="1px solid"
       borderColor="border"
       role={readOnly ? 'img' : undefined}
@@ -198,6 +201,7 @@ export const OddsTimelineBars = React.memo((props: OddsTimelineBarsProps): React
           odds={segment.odds}
           percent={segment.percent}
           timestamp={segment.timestamp}
+          size={size}
         />
       ))}
     </Box>

--- a/src/app/components/timeline/TimelineContent.tsx
+++ b/src/app/components/timeline/TimelineContent.tsx
@@ -1292,7 +1292,7 @@ const PirateTimelineView = React.memo(
     return (
       <>
         <DrawerHeader>
-          <VStack align="stretch">
+          <VStack align="stretch" width="full">
             {/* Breadcrumb Navigation */}
             <Breadcrumb.Root size="md" variant="underline" mb={3}>
               <Breadcrumb.List>
@@ -1361,13 +1361,15 @@ const PirateTimelineView = React.memo(
               </Box>
             </Flex>
             {timelineSegments.length > 0 && (
-              <Box mt={1}>
+              <Box mt={1} width="full">
                 <OddsTimelineBars
                   arenaId={arenaId}
                   pirateIndex={pirateIndex}
                   segments={timelineSegments}
                   readOnly
                   ariaLabel={`${pirateName} odds timeline`}
+                  maxW="full"
+                  size="lg"
                 />
               </Box>
             )}

--- a/src/app/components/timeline/TimelineContent.tsx
+++ b/src/app/components/timeline/TimelineContent.tsx
@@ -17,7 +17,7 @@ import {
   Badge,
   EmptyState,
 } from '@chakra-ui/react';
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import {
   FaUtensils,
   FaSkullCrossbones,
@@ -41,6 +41,8 @@ import { useRoundStore, useCurrentOddsValue, useOpeningOddsValue, useArenaRatios
 import { displayAsPercent } from '../../util';
 import { getOrdinalSuffix, filterChangesByArenaPirate } from '../../utils/betUtils';
 import DateFormatter from '../format/DateFormatter';
+
+import { OddsTimelineBars, buildOddsTimelineSegments } from './OddsTimeline';
 
 import { Avatar } from '@/components/ui/avatar';
 import {
@@ -1211,6 +1213,10 @@ const PirateTimelineView = React.memo(
     const getPirateBgColor = useGetPirateBgColor();
     const currentOdds = useCurrentOddsValue(arenaId, pirateIndex);
     const openingOdds = useOpeningOddsValue(arenaId, pirateIndex);
+    const timelineSegments = useMemo(
+      () => buildOddsTimelineSegments(roundData, arenaId, pirateIndex),
+      [roundData, arenaId, pirateIndex],
+    );
 
     if (!pirateId || !start || !endTime) {
       return null;
@@ -1354,6 +1360,17 @@ const PirateTimelineView = React.memo(
                 )}
               </Box>
             </Flex>
+            {timelineSegments.length > 0 && (
+              <Box mt={1}>
+                <OddsTimelineBars
+                  arenaId={arenaId}
+                  pirateIndex={pirateIndex}
+                  segments={timelineSegments}
+                  readOnly
+                  ariaLabel={`${pirateName} odds timeline`}
+                />
+              </Box>
+            )}
             <Text
               fontSize="sm"
               fontWeight="bold"


### PR DESCRIPTION
## Summary
- Clicking a pirate's odds-timeline bar in the results table opens a drawer with a detailed chronological event list, but the drawer never showed the bar itself - the exact at-a-glance visual the user just clicked.
- Extracted the segment/percentage-building logic out of `OddsTimeline.tsx` into a shared, exported `buildOddsTimelineSegments(roundData, arenaId, pirateIndex)`, so the table-cell bar and the drawer reuse one implementation instead of duplicating the dedup/endTime/percentage math.
- `PirateTimelineView` (the single-pirate drawer view) now renders the same bar, read-only, between the Open/Now odds badges and the vertical "Timeline" event list below it - reusing the `readOnly` mode on `OddsTimelineBars` already proven out by the help-guide example.
- Added an optional `ariaLabel` prop to `OddsTimelineBars` (defaults to the existing docs-example string) so this new real usage gets an accurate label (`"<Pirate> odds timeline"`) instead of the hardcoded "Example odds timeline".
- Scope: only `PirateTimelineView` - it's the only drawer view keyed to one exact `(arenaId, pirateIndex)` pair, matching what a single bar click represents. The arena-grid and overall views were intentionally left untouched (would need a distinct compact-bar design, not a straight reuse).

## Test plan
- [x] `npm run typecheck` passes (same pre-existing, unrelated error in `AllBetsModal.tsx` present on `master` before this change)
- [x] `npm run lint` shows zero new issues (confirmed the 3 pre-existing errors in `TimelineContent.tsx` also exist on bare `master`)
- [x] Verified visually with headless-browser screenshots against a live round:
  - A pirate with multiple odds changes shows a matching multi-segment bar in the drawer
  - A pirate with zero changes shows one full-width segment, no crash
  - Clicking the bar inside the drawer is a no-op (read-only, no duplicate drawer)
  - No new console errors