### PR TITLE
Stop the service worker from force-reloading the page on update

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -17,13 +17,11 @@ window.ENV = {
 
 // Register service worker without automatic updates
 if ('serviceWorker' in navigator) {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const updateSW = registerSW({
+  registerSW({
     immediate: true,
     onNeedRefresh() {
       // Log that a new version is available, but don't force refresh
       console.log('New app version available. Will be applied on next page refresh.');
-      // updateSW(true);
     },
     onOfflineReady() {
       console.log('App ready to work offline');

--- a/vite.config.js
+++ b/vite.config.js
@@ -16,7 +16,7 @@ export default defineConfig({
     }),
     tsconfigPaths(),
     VitePWA({
-      registerType: 'autoUpdate',
+      registerType: 'prompt',
       injectRegister: 'auto',
       manifest: {
         name: 'NeoFoodClub',


### PR DESCRIPTION
## Summary
- `registerType: 'autoUpdate'` in `vite.config.js` bakes an unconditional `window.location.reload()` into the generated service-worker registration on activation (confirmed by reading `vite-plugin-pwa`'s generated `virtual:pwa-register` module) - this bypasses the `onNeedRefresh` handler already written in `src/index.jsx`, which was clearly intended to *not* force a reload (it just logs, with the actual refresh call already commented out) but was dead code under `autoUpdate`.
- Switched `registerType` to `'prompt'`, which makes that existing handler actually take effect: a new version installs and waits silently in the background, and gets applied on the user's next natural page load/navigation instead of yanking away in-progress state (e.g. a bet being built).
- No visible "update available" UI was added - this stays fully silent (console log only), matching the app's existing intent. "prompt" is purely vite-plugin-pwa's internal strategy name here, not anything shown to the user.
- Cleaned up the now-genuinely-dead `eslint-disable`/unused-var wrapper and the commented-out manual-refresh call in `src/index.jsx` since the handler above it now really is the whole story.

## Test plan
- [x] `npm run build` succeeds
- [x] Confirmed in the built bundle (`build/assets/index-*.js`) that the unconditional `activated -> location.reload()` listener is no longer present at all; only the `waiting -> onNeedRefresh` path remains, matching `registerType: 'prompt'`
- [x] `npm run typecheck` / `npm run lint` show no new issues (same pre-existing, unrelated error in `AllBetsModal.tsx` present on `master` already)