### PR TITLE
Fix broken automation-check workflow and add Docker build validation

### DIFF
--- a/.github/workflows/automation-check.yml
+++ b/.github/workflows/automation-check.yml
@@ -6,6 +6,10 @@ on:
       - 'automation/**/*.py'
       - 'automation/pyproject.toml'
       - 'automation/uv.lock'
+      - 'automation/.python-version'
+      - 'automation/Dockerfile'
+      - 'automation/docker-compose.yml'
+      - '.github/workflows/automation-check.yml'
   workflow_run:
     workflows: ['Automation Output Check']
     types: [completed]
@@ -24,7 +28,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version-file: automation/.python-version
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -91,18 +95,30 @@ jobs:
 
       - name: Upload comparison results
         if: always()
-        working-directory: automation
         uses: actions/upload-artifact@v4
         with:
           name: automation-output-check
           path: |
-            compare-result.json
-            diff_output.txt
+            automation/compare-result.json
+            automation/diff_output.txt
           if-no-files-found: ignore
 
       - name: Fail if diff detected
         if: steps.compare.outcome == 'failure'
         run: exit 1
+
+  docker-build-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build automation Docker image
+        working-directory: automation
+        run: docker compose build nfc_values
 
   post-pr-comment:
     if: >


### PR DESCRIPTION
## Summary
- Fixes .github/workflows/automation-check.yml, which has been silently broken since 8285bae: `working-directory` is not a valid key on a `uses:` step (`actions/upload-artifact@v4`), so the entire workflow file fails GitHub's schema validation and zero jobs run on any push/PR. Confirmed via the Actions API that every run since that commit shows `"jobs":[]` and `conclusion: failure` ("This run likely failed because of a workflow file issue").
- Adds a `docker-build-check` job that runs `docker compose build nfc_values`, so a Python-version/base-image mismatch between `pyproject.toml`/`uv.lock` and `automation/Dockerfile` (like the one in #855) fails CI instead of silently breaking the monthly `update_logit_values` cron job.
- Broadens the `pull_request.paths` trigger to include `automation/.python-version`, `automation/Dockerfile`, `automation/docker-compose.yml`, and the workflow file itself.
- Points `actions/setup-python` at `python-version-file: automation/.python-version` instead of a hardcoded version string, removing one of the three places a Python bump needs to be kept in sync.

## Test plan
- [x] `actionlint .github/workflows/automation-check.yml` - syntax-check error is gone (remaining shellcheck notices are pre-existing/info-level, unrelated to this fix)
- [ ] Confirm `check-outputs` and `docker-build-check` actually execute and pass on this PR (not just a "push" stub failure)