### PR TITLE
Parameterize automation Dockerfile's Python version from .python-version

### DIFF
--- a/.github/workflows/automation-check.yml
+++ b/.github/workflows/automation-check.yml
@@ -118,7 +118,10 @@ jobs:
 
       - name: Build automation Docker image
         working-directory: automation
-        run: docker compose build nfc_values
+        run: |
+          PYTHON_VERSION="$(cat .python-version)"
+          export PYTHON_VERSION
+          docker compose build nfc_values
 
   post-pr-comment:
     if: >

--- a/.github/workflows/update_logit_values.yaml
+++ b/.github/workflows/update_logit_values.yaml
@@ -25,6 +25,8 @@ jobs:
       - name: Run Docker
         run: |
           cd ./automation/
+          PYTHON_VERSION="$(cat .python-version)"
+          export PYTHON_VERSION
           docker compose run --rm nfc_values
           cp "./output/typescript.ts" "./../src/app/constants_logit.ts"
 

--- a/automation/Dockerfile
+++ b/automation/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+ARG PYTHON_VERSION=3.13
+FROM ghcr.io/astral-sh/uv:python${PYTHON_VERSION}-bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends git \
     && rm -rf /var/lib/apt/lists/*

--- a/automation/docker-compose.yml
+++ b/automation/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   nfc_values:
-    build: .
+    build:
+      context: .
+      args:
+        PYTHON_VERSION: ${PYTHON_VERSION}
     stop_signal: SIGINT
     volumes:
       - ./raw_json:/app/raw_json


### PR DESCRIPTION
## Summary
- automation/Dockerfile now takes `PYTHON_VERSION` as a build ARG instead of hardcoding the base image tag.
- automation/docker-compose.yml passes it through from the `PYTHON_VERSION` env var.
- Both places that build this image (the `update_logit_values` cron job and `automation-check.yml`'s `docker-build-check` job) now export `PYTHON_VERSION` from `automation/.python-version` before building.

This makes `.python-version` the single source of truth for the automation environment's Python version. Previously the Dockerfile's tag was a separate, manually-maintained value - which is exactly what PR #855 (the Python 3.13 -> 3.14 bump) got wrong, and would have broken the monthly `update_logit_values` cron job had #855 merged as originally opened.

## Test plan
- [x] `actionlint` clean on both modified workflow files
- [x] `docker compose config` confirms `PYTHON_VERSION` correctly threads into the build args
- [ ] Confirm `docker-build-check` passes in CI on this PR