### PR TITLE
Fix self-triggering infinite loop in automation-check.yml

### DIFF
--- a/.github/workflows/automation-check.yml
+++ b/.github/workflows/automation-check.yml
@@ -108,6 +108,7 @@ jobs:
         run: exit 1
 
   docker-build-check:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- `automation-check.yml` has a self-referential `workflow_run: workflows: ['Automation Output Check']` trigger, used so a second run can post the comparison result as a PR comment (since the first, `pull_request`-triggered run can't post comments on a fork-safe token).
- `docker-build-check` (added in #868) has no event guard, unlike `check-outputs` which is gated to `if: github.event_name == 'pull_request'`. So every completion of this workflow - including the workflow_run-triggered follow-up run that only exists to post a comment - re-runs `docker-build-check` for real, which itself is another completion of "Automation Output Check", which re-triggers the workflow_run event again.
- Result: the workflow is stuck in a loop. It's now up to 561+ total runs, and every recent run across every branch (including plain `master` pushes and every Renovate PR) fails instantly in 0s with no jobs listed - GitHub's own loop protection is short-circuiting new runs before they start. No PR is currently getting a real automation output check.

## Fix
Add `if: github.event_name == 'pull_request'` to `docker-build-check`, matching `check-outputs`, so workflow_run-triggered runs do no real work (only `post-pr-comment` should run there) and stop re-triggering the chain.

## Test plan
- [x] Validated the workflow YAML still parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] After merge: confirm a new PR touching `automation/**` gets exactly one real `check-outputs`/`docker-build-check` run plus one comment-posting run, and that the run count stops climbing