### PR TITLE
Rename automation-check.yml to break poisoned workflow_run chain

### DIFF
--- a/.github/workflows/automation-regression-check.yml
+++ b/.github/workflows/automation-regression-check.yml
@@ -1,4 +1,4 @@
-name: Automation Output Check
+name: Automation Regression Check
 
 on:
   pull_request:
@@ -9,9 +9,9 @@ on:
       - 'automation/.python-version'
       - 'automation/Dockerfile'
       - 'automation/docker-compose.yml'
-      - '.github/workflows/automation-check.yml'
+      - '.github/workflows/automation-regression-check.yml'
   workflow_run:
-    workflows: ['Automation Output Check']
+    workflows: ['Automation Regression Check']
     types: [completed]
 
 jobs:
@@ -196,7 +196,7 @@ jobs:
               ].join('\n');
             } else {
               comment = [
-                '## ✅ Automation Output Check Passed',
+                '## ✅ Automation Regression Check Passed',
                 '',
                 'The generated `output/python.py` matches the expected output.',
               ].join('\n');


### PR DESCRIPTION
## Summary
#875 fixed the missing `if: github.event_name == 'pull_request'` guard on `docker-build-check`, which was the proximate cause of the self-triggering `workflow_run` loop (it ran on every completion of this workflow, including workflow_run-triggered ones, each of which is itself a completion that re-triggers the chain).

That fix was necessary but not sufficient. After merging it, every run still failed instantly (0s, no jobs, name falling back to the raw file path instead of the YAML `name:`). Tested three ways:
1. Pushed past the merged fix - still instant failure.
2. Disabled + re-enabled the workflow via the API to reset its registration - still instant failure.
3. Created an entirely new workflow file at a different path with identical (fixed) content - **same instant failure**, which rules out anything specific to the old file/workflow ID.

The one thing every attempt shared: the YAML `name: Automation Output Check` field, matched by the self-referential `workflow_run: workflows: ['Automation Output Check']` trigger. GitHub matches `workflow_run` triggers by name string, not file path/ID, and this repo has 561+ runs of loop history logged against that exact name - my read is GitHub's own workflow-run recursion protection is now blocking anything matching it.

## Fix
Rename the file (`automation-check.yml` -> `automation-regression-check.yml`) and the workflow's `name:` (`Automation Output Check` -> `Automation Regression Check`), updating the self-reference and the file's own entry in `paths:` to match. This gives the workflow a clean identity GitHub hasn't seen before.

## Test plan
- [x] `actionlint` clean (only pre-existing shellcheck info-level notices, unrelated)
- [ ] After this PR opens: confirm `check-outputs`/`docker-build-check` actually execute (not another instant 0s failure) - this PR's own diff touches `.github/workflows/automation-regression-check.yml`, which is in its own `paths:` filter, so it should self-trigger