### PR TITLE
Shard Playwright tests across 4 parallel jobs

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main, master ]
 
 jobs:
-  test:
+  test-shard:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     strategy:
@@ -64,3 +64,16 @@ jobs:
         name: test-results-${{ matrix.shard }}
         path: test-results/
         retention-days: 30
+
+  test:
+    name: test
+    needs: test-shard
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+    - name: Check shard results
+      run: |
+        if [ "${{ needs.test-shard.result }}" != "success" ]; then
+          echo "One or more Playwright shards failed: ${{ needs.test-shard.result }}"
+          exit 1
+        fi

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,6 +10,10 @@ jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
 
     steps:
     - uses: actions/checkout@v7
@@ -42,14 +46,14 @@ jobs:
       if: steps.playwright-cache.outputs.cache-hit == 'true'
       run: npx playwright install-deps chromium firefox webkit
 
-    - name: Run Playwright tests
-      run: npx playwright test
+    - name: Run Playwright tests (shard ${{ matrix.shard }}/4)
+      run: npx playwright test --shard=${{ matrix.shard }}/4
 
     - name: Upload Playwright Report
       uses: actions/upload-artifact@v7
       if: always()
       with:
-        name: playwright-report
+        name: playwright-report-${{ matrix.shard }}
         path: playwright-report/
         retention-days: 30
 
@@ -57,6 +61,6 @@ jobs:
       uses: actions/upload-artifact@v7
       if: always()
       with:
-        name: test-results
+        name: test-results-${{ matrix.shard }}
         path: test-results/
         retention-days: 30


### PR DESCRIPTION
## Summary
- The Playwright CI run was taking ~8 min total, with ~6.5 min spent in the actual test execution step (6 spec files x 5 browser projects, capped at 4 workers on one runner)
- Adds a `matrix.shard: [1,2,3,4]` strategy and passes `--shard=N/4` to `playwright test`, splitting the same full test suite across 4 parallel jobs
- Artifact names include the shard index since upload-artifact requires unique names per job in a run

## Test plan
- [ ] Confirm all 4 shards complete successfully and cover the full suite (no missing/duplicated tests)
- [ ] Compare wall-clock time against the current ~8 min baseline