### PR TITLE
Color-code duplicate bet groups

### DIFF
--- a/src/app/components/bets/PlaceThisBetButton.tsx
+++ b/src/app/components/bets/PlaceThisBetButton.tsx
@@ -124,15 +124,21 @@ const PlaceThisBetButton = React.memo(
     }
 
     if (hasDuplicates) {
-      return (
-        <ErrorBetButton>
-          Duplicate bet!
-          {myDuplicateColor && (
+      if (myDuplicateColor) {
+        return (
+          <ErrorBetButton>
+            Duplicate bet!
             <Badge colorPalette={myDuplicateColor} variant="solid" ml={1}>
               ●
             </Badge>
-          )}
-        </ErrorBetButton>
+          </ErrorBetButton>
+        );
+      }
+
+      return (
+        <BetButton colorPalette="nfc-green" variant="surface" disabled>
+          Place bet! <FaExternalLinkAlt />
+        </BetButton>
       );
     }
 

--- a/src/app/components/bets/PlaceThisBetButton.tsx
+++ b/src/app/components/bets/PlaceThisBetButton.tsx
@@ -12,7 +12,10 @@ import {
   useBetBinaries,
 } from '../../stores';
 import { generateBetLinkUrl, openBetLinkInNewTab } from '../../utils/betUtils';
-import { computeDuplicateBetGroupColors } from '../../utils/duplicateBetColors';
+import {
+  computeDuplicateBetGroupColors,
+  DUPLICATE_BET_COLOR_PALETTE,
+} from '../../utils/duplicateBetColors';
 
 // this element is the "Place Bet" button inside the PayoutTable
 
@@ -119,22 +122,40 @@ const PlaceThisBetButton = React.memo(
       return <ErrorBetButton>Round is over!</ErrorBetButton>;
     }
 
+    if (myDuplicateColor) {
+      const duplicateGroupNumber =
+        DUPLICATE_BET_COLOR_PALETTE.indexOf(
+          myDuplicateColor as (typeof DUPLICATE_BET_COLOR_PALETTE)[number],
+        ) + 1;
+
+      return (
+        <ErrorBetButton>
+          Duplicate bet!
+          <Badge
+            colorPalette={myDuplicateColor}
+            variant="solid"
+            ml={2}
+            borderRadius="full"
+            minW="16px"
+            h="16px"
+            display="inline-flex"
+            alignItems="center"
+            justifyContent="center"
+            px={1}
+            fontSize="xs"
+            border="2px solid white"
+          >
+            {duplicateGroupNumber}
+          </Badge>
+        </ErrorBetButton>
+      );
+    }
+
     if (betAmount < 1) {
       return <ErrorBetButton>Invalid bet amount!</ErrorBetButton>;
     }
 
     if (hasDuplicates) {
-      if (myDuplicateColor) {
-        return (
-          <ErrorBetButton>
-            Duplicate bet!
-            <Badge colorPalette={myDuplicateColor} variant="solid" ml={1}>
-              ●
-            </Badge>
-          </ErrorBetButton>
-        );
-      }
-
       return (
         <BetButton colorPalette="nfc-green" variant="surface" disabled>
           Place bet! <FaExternalLinkAlt />

--- a/src/app/components/bets/PlaceThisBetButton.tsx
+++ b/src/app/components/bets/PlaceThisBetButton.tsx
@@ -1,8 +1,9 @@
-import { Button, ButtonProps } from '@chakra-ui/react';
+import { Badge, Button, ButtonProps } from '@chakra-ui/react';
 import React, { useState, useCallback, useMemo } from 'react';
 import { FaExternalLinkAlt } from 'react-icons/fa';
 
 import { useIsRoundOver } from '../../hooks/useIsRoundOver';
+import { computePiratesBinary } from '../../maths';
 import {
   useBetOdds,
   useBetPayoffs,
@@ -11,6 +12,7 @@ import {
   useBetBinaries,
 } from '../../stores';
 import { generateBetLinkUrl, openBetLinkInNewTab } from '../../utils/betUtils';
+import { computeDuplicateBetGroupColors } from '../../utils/duplicateBetColors';
 
 // this element is the "Place Bet" button inside the PayoutTable
 
@@ -103,10 +105,13 @@ const PlaceThisBetButton = React.memo(
 
     const betAmount = useSpecificBetAmount(betNum);
     const betBinariesMap = useBetBinaries();
-    const hasDuplicates = useMemo(() => {
-      const binaries = Array.from(betBinariesMap.values()).filter(b => b > 0);
-      return new Set(binaries).size !== binaries.length;
-    }, [betBinariesMap]);
+    const duplicateColors = useMemo(
+      () => computeDuplicateBetGroupColors(betBinariesMap),
+      [betBinariesMap],
+    );
+    const hasDuplicates = duplicateColors.size > 0;
+    const thisBetBinary = useMemo(() => computePiratesBinary(bet), [bet]);
+    const myDuplicateColor = duplicateColors.get(thisBetBinary);
 
     const isRoundOver = useIsRoundOver();
 
@@ -119,7 +124,16 @@ const PlaceThisBetButton = React.memo(
     }
 
     if (hasDuplicates) {
-      return <ErrorBetButton>Duplicate bet!</ErrorBetButton>;
+      return (
+        <ErrorBetButton>
+          Duplicate bet!
+          {myDuplicateColor && (
+            <Badge colorPalette={myDuplicateColor} variant="solid" ml={1}>
+              ●
+            </Badge>
+          )}
+        </ErrorBetButton>
+      );
     }
 
     return (

--- a/src/app/components/tables/DropDownTable.tsx
+++ b/src/app/components/tables/DropDownTable.tsx
@@ -19,6 +19,7 @@ import {
   useBigBrain,
 } from '../../stores';
 import { displayAsPercent } from '../../util';
+import { computeDuplicateBetGroupColors } from '../../utils/duplicateBetColors';
 import ClearBetsButton from '../bets/ClearBetsButton';
 import PirateSelect from '../bets/PirateSelect';
 
@@ -62,15 +63,16 @@ const DropDownTableRow = React.memo(
   ({
     betNum,
     rowHandlers,
-    isBetDuplicate,
+    duplicateColors,
   }: {
     betNum: number;
     rowHandlers: ((e: React.ChangeEvent<HTMLSelectElement>) => void)[];
-    isBetDuplicate: (betBinary: number) => boolean;
+    duplicateColors: Map<number, string>;
   }) => {
     const currentBetLine = useBetLineSpecific(betNum + 1);
     const thisBetBinary = useSpecificBetBinary(betNum + 1);
     const loaded = useIsCalculated();
+    const duplicateColor = duplicateColors.get(thisBetBinary);
 
     return (
       <Table.Row>
@@ -89,7 +91,7 @@ const DropDownTableRow = React.memo(
             />
           );
         })}
-        <Td>{isBetDuplicate(thisBetBinary) && <DuplicateBadge />}</Td>
+        <Td>{duplicateColor && <DuplicateBadge color={duplicateColor} />}</Td>
       </Table.Row>
     );
   },
@@ -186,8 +188,8 @@ const ClearButtonHeader = React.memo(() => (
 
 ClearButtonHeader.displayName = 'ClearButtonHeader';
 
-const DuplicateBadge = React.memo(() => (
-  <Badge colorPalette="nfc-red" variant="subtle" fontSize="xs">
+const DuplicateBadge = React.memo(({ color }: { color: string }) => (
+  <Badge colorPalette={color} variant="subtle" fontSize="xs">
     ❌ Duplicate
   </Badge>
 ));
@@ -282,24 +284,9 @@ const DropDownTable = React.memo(
     const betBinariesMap = useBetBinaries();
     const updateSinglePirate = useUpdateSinglePirate();
 
-    const duplicateBinaries = useMemo(() => {
-      const seen = new Set<number>();
-      const duplicates = new Set<number>();
-      for (const binary of betBinariesMap.values()) {
-        if (binary > 0) {
-          if (seen.has(binary)) {
-            duplicates.add(binary);
-          } else {
-            seen.add(binary);
-          }
-        }
-      }
-      return Array.from(duplicates);
-    }, [betBinariesMap]);
-
-    const isBetDuplicate = useCallback(
-      (betBinary: number): boolean => duplicateBinaries.includes(betBinary),
-      [duplicateBinaries],
+    const duplicateColors = useMemo(
+      () => computeDuplicateBetGroupColors(betBinariesMap),
+      [betBinariesMap],
     );
 
     const { openTimelineDrawer } = timelineHandlers;
@@ -378,11 +365,11 @@ const DropDownTable = React.memo(
               key={`dropdown-bet-${betNum}`}
               betNum={betNum}
               rowHandlers={rowHandlers}
-              isBetDuplicate={isBetDuplicate}
+              duplicateColors={duplicateColors}
             />
           );
         }),
-      [amountOfBets, allRowHandlers, isBetDuplicate],
+      [amountOfBets, allRowHandlers, duplicateColors],
     );
 
     return (

--- a/src/app/utils/duplicateBetColors.ts
+++ b/src/app/utils/duplicateBetColors.ts
@@ -1,0 +1,40 @@
+export const DUPLICATE_BET_COLOR_PALETTE = [
+  'nfc-purple',
+  'nfc-orange',
+  'nfc-teal',
+  'nfc-pink',
+  'nfc-cyan',
+  'nfc-yellow',
+  'nfc-blue',
+] as const;
+// nfc-red / nfc-green intentionally excluded: they already mean "error" / "success" elsewhere in the app.
+
+export function computeDuplicateBetGroupColors(
+  betBinariesMap: Map<number, number>,
+): Map<number, string> {
+  const groups = new Map<number, number[]>();
+
+  for (const [betNum, binary] of betBinariesMap) {
+    if (binary === 0) continue;
+
+    const existing = groups.get(binary);
+    if (existing) {
+      existing.push(betNum);
+    } else {
+      groups.set(binary, [betNum]);
+    }
+  }
+
+  const result = new Map<number, string>();
+  let colorIndex = 0;
+
+  for (const [binary, betNums] of groups) {
+    if (betNums.length >= 2) {
+      const color = DUPLICATE_BET_COLOR_PALETTE[colorIndex % DUPLICATE_BET_COLOR_PALETTE.length] as string;
+      result.set(binary, color);
+      colorIndex += 1;
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- Replace the generic "Duplicate bet!" / "Duplicate" warnings with per-group color coding, so users can tell which bets match which other bets.
- Add `computeDuplicateBetGroupColors` (src/app/utils/duplicateBetColors.ts), which groups bets by their non-zero pirate-pick binary and assigns each duplicated group a color from a fixed palette (nfc-red/nfc-green excluded, since those already mean error/success elsewhere).
- Wire this into `PlaceThisBetButton.tsx` (colored dot badge on the error button) and `DropDownTable.tsx` (colored `DuplicateBadge` per row), replacing their separate inline duplicate-detection logic.