### PR TITLE
Show share bet URL buttons in view mode

### DIFF
--- a/src/app/BetFunctions.tsx
+++ b/src/app/BetFunctions.tsx
@@ -532,7 +532,7 @@ function createHtmlTable(
   return html;
 }
 
-const BetCopyButtons = React.memo(
+export const BetCopyButtons = React.memo(
   (props: { index: number; [key: string]: unknown }): React.ReactElement => {
     const { index, ...rest } = props;
     const currentSelectedRound = useSelectedRound();

--- a/src/app/components/views/EditBets.tsx
+++ b/src/app/components/views/EditBets.tsx
@@ -307,7 +307,7 @@ export default React.memo(function EditBets(): React.ReactElement {
       {viewMode && (
         <>
           <Box bgColor={'bg.emphasized'} p={4}>
-            <Flex align="center" justify="space-between" wrap="wrap" gap={2}>
+            <Flex align="center" justify="flex-start" wrap="wrap" gap={4}>
               <Button colorPalette="blackAlpha" onClick={handleEditModeClick}>
                 <FaPenToSquare />
                 Edit these bets

--- a/src/app/components/views/EditBets.tsx
+++ b/src/app/components/views/EditBets.tsx
@@ -25,8 +25,10 @@ import React, {
 import { FaPenToSquare, FaGear } from 'react-icons/fa6';
 import Cookies from 'universal-cookie';
 
+import { BetCopyButtons } from '../../BetFunctions';
 import {
   useBetSetPosition,
+  useCurrentBet,
   useHasAnyBets,
   useRoundStore,
   useTableMode,
@@ -132,6 +134,7 @@ PirateTable.displayName = 'PirateTable';
 export default React.memo(function EditBets(): React.ReactElement {
   const viewMode = useViewMode();
   const anyBets = useHasAnyBets();
+  const currentBetIndex = useCurrentBet();
   const setViewMode = useRoundStore(state => state.setViewMode);
   const [isPending, startTransition] = useTransition();
   const [isEditorPrefetched, setIsEditorPrefetched] = useState(false);
@@ -304,10 +307,13 @@ export default React.memo(function EditBets(): React.ReactElement {
       {viewMode && (
         <>
           <Box bgColor={'bg.emphasized'} p={4}>
-            <Button colorPalette="blackAlpha" onClick={handleEditModeClick}>
-              <FaPenToSquare />
-              Edit these bets
-            </Button>
+            <Flex align="center" justify="space-between" wrap="wrap" gap={2}>
+              <Button colorPalette="blackAlpha" onClick={handleEditModeClick}>
+                <FaPenToSquare />
+                Edit these bets
+              </Button>
+              {anyBets ? <BetCopyButtons index={currentBetIndex} /> : null}
+            </Flex>
           </Box>
 
           {/* Prefetch the heavy editor table in the background to speed up the click into edit mode */}


### PR DESCRIPTION
## Summary
- The share/copy buttons (Copy Bet URL, Copy Bet URL with amounts, Copy Markdown/HTML) previously only mounted inside edit mode, nested under the current BetCard.
- View mode now shows these buttons directly in the banner next to "Edit these bets", so users can grab a share link without entering edit mode first.