### PR TITLE
Add unit tests for maths.ts, betUtils.ts, duplicateBetColors.ts, and util.ts gaps

### DIFF
--- a/src/app/__tests__/maths.test.ts
+++ b/src/app/__tests__/maths.test.ts
@@ -1,0 +1,335 @@
+import { describe, it, expect } from 'vitest';
+
+import { makeRoundData } from '../../test/utils';
+import { PayoutData } from '../../types';
+import { Bet, ProbabilitiesData } from '../../types/bets';
+import {
+  makeEmpty,
+  computePirateFAs,
+  computeLegacyProbabilities,
+  computeLogitProbabilities,
+  calculateArenaRatios,
+  calculatePayoutTables,
+  computePirateBinary,
+  computePiratesBinary,
+  computeBinaryToPirates,
+} from '../maths';
+
+// Verifies the internal invariants that `tableToList` (used inside calculatePayoutTables)
+// guarantees for every payout table it produces: values sorted ascending, cumulative
+// non-decreasing and summing toward 1, and tail == 1 - (cumulative before this entry).
+function assertPayoutDataInvariants(list: PayoutData[]): void {
+  expect(list.length).toBeGreaterThan(0);
+
+  for (let i = 1; i < list.length; i++) {
+    expect(list[i]!.value).toBeGreaterThan(list[i - 1]!.value);
+  }
+
+  let runningCumulative = 0;
+  for (let i = 0; i < list.length; i++) {
+    const item = list[i]!;
+    expect(item.tail).toBeCloseTo(1 - runningCumulative, 9);
+    runningCumulative += item.probability;
+    expect(item.cumulative).toBeCloseTo(runningCumulative, 9);
+    expect(item.cumulative).toBeGreaterThanOrEqual(i === 0 ? 0 : list[i - 1]!.cumulative - 1e-9);
+  }
+
+  expect(list[list.length - 1]!.cumulative).toBeCloseTo(1, 9);
+}
+
+describe('makeEmpty', () => {
+  it('creates an array of the given length filled with zeroes', () => {
+    expect(makeEmpty(5)).toEqual([0, 0, 0, 0, 0]);
+  });
+
+  it('creates an empty array for length 0', () => {
+    expect(makeEmpty(0)).toEqual([]);
+  });
+});
+
+describe('computePirateFAs', () => {
+  it('returns a Map with 5 arena entries, each with 4 [favorite, allergy] pairs', () => {
+    const result = computePirateFAs(makeRoundData());
+    expect(result.size).toBe(5);
+    for (let arenaIndex = 0; arenaIndex < 5; arenaIndex++) {
+      const arenaFAs = result.get(arenaIndex);
+      expect(arenaFAs).toBeDefined();
+      expect(arenaFAs).toHaveLength(4);
+      arenaFAs!.forEach(pair => {
+        expect(pair).toHaveLength(2);
+        expect(Number.isFinite(pair[0])).toBe(true);
+        expect(Number.isFinite(pair[1])).toBe(true);
+      });
+    }
+  });
+
+  it('computes exact favorite/allergy values for a known pirate/food combination', () => {
+    // Default fixture: arena 0 pirates are [1,2,3,4], arena 0 foods are [1,2,3,4].
+    // POSITIVE_FAS[1] = { 1: 2, 2: 0, 3: 0, 4: 1, ... } => sum for foods [1,2,3,4] = 3.
+    // NEGATIVE_FAS[1] = { 1: 0, 2: 0, 3: 0, 4: 0, ... } => sum for foods [1,2,3,4] = 0.
+    const result = computePirateFAs(makeRoundData());
+    const arena0 = result.get(0)!;
+    expect(arena0[0]).toEqual([3, 0]);
+  });
+
+  it('returns all zeroes when foods is an empty array', () => {
+    const result = computePirateFAs(makeRoundData({ foods: [] }));
+    for (let arenaIndex = 0; arenaIndex < 5; arenaIndex++) {
+      const arenaFAs = result.get(arenaIndex)!;
+      arenaFAs.forEach(pair => {
+        expect(pair).toEqual([0, 0]);
+      });
+    }
+  });
+
+  it('returns all zeroes when pirates is an empty array', () => {
+    const result = computePirateFAs(makeRoundData({ pirates: [] }));
+    for (let arenaIndex = 0; arenaIndex < 5; arenaIndex++) {
+      const arenaFAs = result.get(arenaIndex)!;
+      arenaFAs.forEach(pair => {
+        expect(pair).toEqual([0, 0]);
+      });
+    }
+  });
+});
+
+describe('computeLegacyProbabilities', () => {
+  it('returns the default arena-numbers shape when openingOdds is an empty array', () => {
+    const result = computeLegacyProbabilities(makeRoundData({ openingOdds: [] }));
+    expect(result.min).toEqual([
+      [1, 0, 0, 0, 0],
+      [1, 0, 0, 0, 0],
+      [1, 0, 0, 0, 0],
+      [1, 0, 0, 0, 0],
+      [1, 0, 0, 0, 0],
+    ]);
+    expect(result.std).toEqual(result.min);
+    expect(result.max).toEqual(result.min);
+    expect(result.used).toEqual(result.min);
+  });
+
+  it('index 0 of every sub-array always stays 1 (unused placeholder slot)', () => {
+    const result = computeLegacyProbabilities(makeRoundData());
+    for (let arenaIndex = 0; arenaIndex < 5; arenaIndex++) {
+      expect(result.min[arenaIndex]![0]).toBe(1);
+      expect(result.max[arenaIndex]![0]).toBe(1);
+      expect(result.std[arenaIndex]![0]).toBe(1);
+      expect(result.used[arenaIndex]![0]).toBe(1);
+    }
+  });
+
+  it('normalizes "used" probabilities to sum to 1 per arena for default odds (hits the odds===2 branch)', () => {
+    // Default fixture openingOdds per arena is [1,2,3,4,5], so pirateIndex 1 has odds
+    // exactly 2, which hits the `pirateOdd === 2` special case in the implementation.
+    const result = computeLegacyProbabilities(makeRoundData());
+    for (let arenaIndex = 0; arenaIndex < 5; arenaIndex++) {
+      const sum =
+        result.used[arenaIndex]![1]! +
+        result.used[arenaIndex]![2]! +
+        result.used[arenaIndex]![3]! +
+        result.used[arenaIndex]![4]!;
+      expect(sum).toBeCloseTo(1, 9);
+    }
+  });
+
+  it('handles odds of exactly 13 without crashing and still normalizes to 1 (hits the odds===13 branch)', () => {
+    const roundData = makeRoundData({
+      openingOdds: [
+        [1, 13, 3, 4, 5],
+        [1, 2, 3, 4, 5],
+        [1, 2, 3, 4, 5],
+        [1, 2, 3, 4, 5],
+        [1, 2, 3, 4, 5],
+      ],
+    });
+    const result = computeLegacyProbabilities(roundData);
+    const sum =
+      result.used[0]![1]! + result.used[0]![2]! + result.used[0]![3]! + result.used[0]![4]!;
+    expect(sum).toBeCloseTo(1, 9);
+    expect(Number.isFinite(result.used[0]![1]!)).toBe(true);
+  });
+});
+
+describe('computeLogitProbabilities', () => {
+  it('returns empty prob/used arrays when pirates is an empty array', () => {
+    const result = computeLogitProbabilities(makeRoundData({ pirates: [] }));
+    expect(result.prob).toEqual([]);
+    expect(result.used).toEqual([]);
+  });
+
+  it('computes normalized probabilities for each arena that sum to 1 across pirates 1-4', () => {
+    const result = computeLogitProbabilities(makeRoundData());
+    expect(result.prob).toHaveLength(5);
+    for (let arenaIndex = 0; arenaIndex < 5; arenaIndex++) {
+      expect(result.prob[arenaIndex]![0]).toBe(1);
+      const sum =
+        result.prob[arenaIndex]![1]! +
+        result.prob[arenaIndex]![2]! +
+        result.prob[arenaIndex]![3]! +
+        result.prob[arenaIndex]![4]!;
+      expect(sum).toBeCloseTo(1, 9);
+      // `used` mirrors `prob` in this implementation
+      expect(result.used[arenaIndex]).toEqual(result.prob[arenaIndex]);
+    }
+  });
+});
+
+describe('calculateArenaRatios', () => {
+  it('computes 1/(sum of 1/odds) - 1 for each arena', () => {
+    const customOdds = [
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+    ];
+    const expectedRatio = 1 / (1 / 2 + 1 / 3 + 1 / 4 + 1 / 5) - 1;
+    const result = calculateArenaRatios(customOdds);
+    expect(result).toHaveLength(5);
+    result.forEach(ratio => {
+      expect(ratio).toBeCloseTo(expectedRatio, 9);
+    });
+  });
+
+  it('computes different ratios per arena when odds differ', () => {
+    const customOdds = [
+      [1, 2, 2, 2, 2],
+      [1, 10, 10, 10, 10],
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+    ];
+    const result = calculateArenaRatios(customOdds);
+    const expectedArena0 = 1 / (1 / 2 + 1 / 2 + 1 / 2 + 1 / 2) - 1;
+    const expectedArena1 = 1 / (1 / 10 + 1 / 10 + 1 / 10 + 1 / 10) - 1;
+    expect(result[0]).toBeCloseTo(expectedArena0, 9);
+    expect(result[1]).toBeCloseTo(expectedArena1, 9);
+  });
+});
+
+describe('computePirateBinary', () => {
+  it('returns 0 when pirateIndex is 0, regardless of arena', () => {
+    for (let arenaIndex = 0; arenaIndex < 5; arenaIndex++) {
+      expect(computePirateBinary(arenaIndex, 0)).toBe(0);
+    }
+  });
+
+  it('returns the expected bit for arena 0 pirates 1-4', () => {
+    expect(computePirateBinary(0, 1)).toBe(0x80000);
+    expect(computePirateBinary(0, 2)).toBe(0x40000);
+    expect(computePirateBinary(0, 3)).toBe(0x20000);
+    expect(computePirateBinary(0, 4)).toBe(0x10000);
+  });
+
+  it('returns the expected bit for arena 4 pirates 1-4', () => {
+    expect(computePirateBinary(4, 1)).toBe(0x8);
+    expect(computePirateBinary(4, 2)).toBe(0x4);
+    expect(computePirateBinary(4, 3)).toBe(0x2);
+    expect(computePirateBinary(4, 4)).toBe(0x1);
+  });
+});
+
+describe('computePiratesBinary', () => {
+  it('returns 0 for an all-zero selection', () => {
+    expect(computePiratesBinary([0, 0, 0, 0, 0])).toBe(0);
+  });
+
+  it('ORs together the per-arena bits for pirateIndex 1 in every arena', () => {
+    expect(computePiratesBinary([1, 1, 1, 1, 1])).toBe(0x88888);
+  });
+
+  it('matches manual OR of computePirateBinary for a mixed selection', () => {
+    const selection = [1, 2, 3, 4, 0];
+    const expected =
+      computePirateBinary(0, 1) |
+      computePirateBinary(1, 2) |
+      computePirateBinary(2, 3) |
+      computePirateBinary(3, 4) |
+      computePirateBinary(4, 0);
+    expect(computePiratesBinary(selection)).toBe(expected);
+  });
+});
+
+describe('computeBinaryToPirates', () => {
+  it('returns all zeroes for binary 0', () => {
+    expect(computeBinaryToPirates(0)).toEqual([0, 0, 0, 0, 0]);
+  });
+
+  it.each([
+    [0, 0, 0, 0, 0],
+    [1, 2, 3, 4, 1],
+    [4, 3, 2, 1, 0],
+    [1, 1, 1, 1, 1],
+    [4, 4, 4, 4, 4],
+    [0, 4, 0, 1, 0],
+  ])('round-trips computeBinaryToPirates(computePiratesBinary(%j))', (...selection) => {
+    // Since computePiratesBinary sets at most one bit per arena (or none for pirateIndex 0),
+    // the encode/decode pair is a true round-trip for any single-pirate-per-arena selection.
+    const binary = computePiratesBinary(selection);
+    expect(computeBinaryToPirates(binary)).toEqual(selection);
+  });
+});
+
+describe('calculatePayoutTables', () => {
+  it('produces internally consistent odds/winnings tables for a small 2-bet set', () => {
+    const bets: Bet = new Map([
+      [1, [1, 0, 0, 0, 0]],
+      [2, [2, 0, 0, 0, 0]],
+    ]);
+    const probabilities: ProbabilitiesData = [
+      [0, 0.4, 0.3, 0.2, 0.1],
+      [0, 0.25, 0.25, 0.25, 0.25],
+      [0, 0.25, 0.25, 0.25, 0.25],
+      [0, 0.25, 0.25, 0.25, 0.25],
+      [0, 0.25, 0.25, 0.25, 0.25],
+    ];
+    const betOdds = new Map([
+      [1, 2],
+      [2, 3],
+    ]);
+    const betPayoffs = new Map([
+      [1, 200],
+      [2, 300],
+    ]);
+
+    const result = calculatePayoutTables(bets, probabilities, betOdds, betPayoffs);
+
+    assertPayoutDataInvariants(result.odds);
+    assertPayoutDataInvariants(result.winnings);
+
+    // Both bets are single-arena, mutually exclusive (arena 0 pirate 1 vs pirate 2), so the
+    // "no bet wins" outcome must also appear as one of the entries (value 0).
+    expect(result.odds.some(entry => entry.value === 0)).toBe(true);
+    expect(result.winnings.some(entry => entry.value === 0)).toBe(true);
+  });
+
+  it('produces internally consistent tables for a 3-bet set with overlapping arenas', () => {
+    const bets: Bet = new Map([
+      [1, [1, 1, 0, 0, 0]],
+      [2, [1, 2, 0, 0, 0]],
+      [3, [2, 0, 0, 0, 0]],
+    ]);
+    const probabilities: ProbabilitiesData = [
+      [0, 0.4, 0.3, 0.2, 0.1],
+      [0, 0.5, 0.2, 0.2, 0.1],
+      [0, 0.25, 0.25, 0.25, 0.25],
+      [0, 0.25, 0.25, 0.25, 0.25],
+      [0, 0.25, 0.25, 0.25, 0.25],
+    ];
+    const betOdds = new Map([
+      [1, 4],
+      [2, 5],
+      [3, 6],
+    ]);
+    const betPayoffs = new Map([
+      [1, 400],
+      [2, 500],
+      [3, 600],
+    ]);
+
+    const result = calculatePayoutTables(bets, probabilities, betOdds, betPayoffs);
+
+    assertPayoutDataInvariants(result.odds);
+    assertPayoutDataInvariants(result.winnings);
+  });
+});

--- a/src/app/__tests__/util.test.ts
+++ b/src/app/__tests__/util.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { RoundState } from '../../types';
 import { Bet, BetAmount } from '../../types/bets';
 import { BET_AMOUNT_DEFAULT, BET_AMOUNT_MAX } from '../constants';
+import { computePiratesBinary } from '../maths';
 import {
   generateRandomIntegerInRange,
   generateRandomPirateIndex,
@@ -27,6 +28,12 @@ import {
   determineBetAmount,
   formatDate,
   getMaxSmartPercentDecimals,
+  getTableMode,
+  getBetSetPosition,
+  getBigBrainMode,
+  makeBetValues,
+  calculateRoundData,
+  calculateBetMaps,
 } from '../util';
 
 // Mock universal-cookie
@@ -835,5 +842,349 @@ describe('Utility Functions', () => {
       const result = formatDate('', { fromNow: true });
       expect(result).toBe('');
     });
+  });
+});
+
+describe('Cookie-backed settings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCookie.mockReset();
+  });
+
+  describe('getTableMode', () => {
+    it('returns the default "normal" when no cookie is set', () => {
+      mockGetCookie.mockReturnValue(undefined);
+      expect(getTableMode()).toBe('normal');
+    });
+
+    it('returns the cookie value when it is a valid option', () => {
+      mockGetCookie.mockReturnValue('dropdown');
+      expect(getTableMode()).toBe('dropdown');
+    });
+
+    it('falls back to the default when the cookie value is invalid', () => {
+      mockGetCookie.mockReturnValue('garbage');
+      expect(getTableMode()).toBe('normal');
+    });
+  });
+
+  describe('getBetSetPosition', () => {
+    it('returns the default "below" when no cookie is set', () => {
+      mockGetCookie.mockReturnValue(undefined);
+      expect(getBetSetPosition()).toBe('below');
+    });
+
+    it('returns the cookie value when it is a valid option', () => {
+      mockGetCookie.mockReturnValue('left');
+      expect(getBetSetPosition()).toBe('left');
+    });
+
+    it('returns "right" when the cookie is set to "right"', () => {
+      mockGetCookie.mockReturnValue('right');
+      expect(getBetSetPosition()).toBe('right');
+    });
+
+    it('falls back to the default when the cookie value is invalid', () => {
+      mockGetCookie.mockReturnValue('sideways');
+      expect(getBetSetPosition()).toBe('below');
+    });
+  });
+
+  describe('getBigBrainMode', () => {
+    it('returns the default true when no cookie is set', () => {
+      mockGetCookie.mockReturnValue(undefined);
+      expect(getBigBrainMode()).toBe(true);
+    });
+
+    it('returns true when the cookie is the boolean true', () => {
+      mockGetCookie.mockReturnValue(true);
+      expect(getBigBrainMode()).toBe(true);
+    });
+
+    it('returns false when the cookie is the boolean false', () => {
+      mockGetCookie.mockReturnValue(false);
+      expect(getBigBrainMode()).toBe(false);
+    });
+
+    it('returns false when the cookie is the string "false"', () => {
+      mockGetCookie.mockReturnValue('false');
+      expect(getBigBrainMode()).toBe(false);
+    });
+
+    it('returns true when the cookie is the string "true"', () => {
+      mockGetCookie.mockReturnValue('true');
+      expect(getBigBrainMode()).toBe(true);
+    });
+
+    it('falls back to the default when the cookie is an invalid/garbage string', () => {
+      mockGetCookie.mockReturnValue('garbage');
+      expect(getBigBrainMode()).toBe(true);
+    });
+
+    it('coerces numeric cookies (0 is false, nonzero is true)', () => {
+      mockGetCookie.mockReturnValue(0);
+      expect(getBigBrainMode()).toBe(false);
+      mockGetCookie.mockReturnValue(1);
+      expect(getBigBrainMode()).toBe(true);
+    });
+  });
+});
+
+describe('makeBetValues', () => {
+  it('forces oddsProduct/probProduct/payoff to 0 for an all-zero bet', () => {
+    const bets: Bet = new Map([[1, [0, 0, 0, 0, 0]]]);
+    const betAmounts: BetAmount = new Map([[1, 100]]);
+    const odds = [
+      [0, 2, 3, 4, 5],
+      [0, 2, 3, 4, 5],
+      [0, 2, 3, 4, 5],
+      [0, 2, 3, 4, 5],
+      [0, 2, 3, 4, 5],
+    ];
+    const probabilities = [
+      [0, 0.25, 0.25, 0.25, 0.25],
+      [0, 0.25, 0.25, 0.25, 0.25],
+      [0, 0.25, 0.25, 0.25, 0.25],
+      [0, 0.25, 0.25, 0.25, 0.25],
+      [0, 0.25, 0.25, 0.25, 0.25],
+    ];
+
+    const result = makeBetValues(bets, betAmounts, odds, probabilities);
+
+    expect(result.betBinaries.get(1)).toBe(0);
+    expect(result.betOdds.get(1)).toBe(0);
+    expect(result.betProbabilities.get(1)).toBe(0);
+    expect(result.betPayoffs.get(1)).toBe(0);
+    expect(result.betExpectedRatios.get(1)).toBe(0);
+    expect(result.betNetExpected.get(1)).toBe(-100);
+    expect(result.betMaxBets.get(1)).toBe(1_000_000);
+  });
+
+  it('computes exact odds/probability/payoff products for a normal 5-arena bet', () => {
+    const bets: Bet = new Map([[1, [1, 2, 3, 4, 1]]]);
+    const betAmounts: BetAmount = new Map([[1, 10]]);
+    const odds = [
+      [0, 2, 0, 0, 0],
+      [0, 0, 3, 0, 0],
+      [0, 0, 0, 4, 0],
+      [0, 0, 0, 0, 5],
+      [0, 6, 0, 0, 0],
+    ];
+    const probabilities = [
+      [0, 0.5, 0, 0, 0],
+      [0, 0, 0.4, 0, 0],
+      [0, 0, 0, 0.3, 0],
+      [0, 0, 0, 0, 0.2],
+      [0, 0.1, 0, 0, 0],
+    ];
+
+    const result = makeBetValues(bets, betAmounts, odds, probabilities);
+
+    expect(result.betBinaries.get(1)).toBeGreaterThan(0);
+    expect(result.betOdds.get(1)).toBe(720); // 2*3*4*5*6
+    expect(result.betProbabilities.get(1)!).toBeCloseTo(0.0012, 9); // 0.5*0.4*0.3*0.2*0.1
+    expect(result.betPayoffs.get(1)).toBe(7200); // 10 * 720
+    expect(result.betExpectedRatios.get(1)!).toBeCloseTo(0.864, 9); // 720 * 0.0012
+    expect(result.betNetExpected.get(1)!).toBeCloseTo(-1.36, 9); // 7200*0.0012 - 10
+    expect(result.betMaxBets.get(1)).toBe(1388); // floor(1_000_000 / 720)
+  });
+
+  it('caps payoff at 1,000,000', () => {
+    const bets: Bet = new Map([[1, [1, 0, 0, 0, 0]]]);
+    const betAmounts: BetAmount = new Map([[1, 1000]]);
+    const odds = [
+      [0, 5000, 0, 0, 0],
+      [0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0],
+    ];
+    const probabilities = [
+      [0, 0.1, 0, 0, 0],
+      [0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0],
+    ];
+
+    const result = makeBetValues(bets, betAmounts, odds, probabilities);
+
+    expect(result.betOdds.get(1)).toBe(5000);
+    // amount * oddsProduct = 1000 * 5000 = 5,000,000, capped at 1,000,000
+    expect(result.betPayoffs.get(1)).toBe(1_000_000);
+  });
+
+  it('returns all-empty maps for an empty bets Map', () => {
+    const bets: Bet = new Map();
+    const betAmounts: BetAmount = new Map();
+    const odds = [[], [], [], [], []];
+    const probabilities = [[], [], [], [], []];
+
+    const result = makeBetValues(bets, betAmounts, odds, probabilities);
+
+    expect(result.betBinaries.size).toBe(0);
+    expect(result.betOdds.size).toBe(0);
+    expect(result.betPayoffs.size).toBe(0);
+    expect(result.betProbabilities.size).toBe(0);
+    expect(result.betExpectedRatios.size).toBe(0);
+    expect(result.betNetExpected.size).toBe(0);
+    expect(result.betMaxBets.size).toBe(0);
+  });
+});
+
+describe('calculateRoundData', () => {
+  it('returns the uncalculated default shape when called with no arguments', () => {
+    const result = calculateRoundData();
+
+    expect(result.calculated).toBe(false);
+    expect(result.odds).toEqual([]);
+    expect(result.legacyProbabilities).toEqual({ min: [], std: [], max: [], used: [] });
+    expect(result.logitProbabilities).toEqual({ prob: [], used: [] });
+    expect(result.usedProbabilities).toEqual([]);
+    expect(result.pirateFAs.size).toBe(0);
+    expect(result.arenaRatios).toEqual([]);
+    expect(result.betOdds.size).toBe(0);
+    expect(result.betBinaries.size).toBe(0);
+    expect(result.payoutTables).toEqual({ odds: [], winnings: [] });
+    expect(result.winningBetBinary).toBe(0);
+    expect(result.totalBetAmounts).toBe(0);
+    expect(result.totalEnabledBets).toBe(0);
+  });
+
+  it('populates calculated fields for a valid round/bets/betAmounts combination', () => {
+    const roundState: RoundState = {
+      roundData: {
+        round: 8000,
+        pirates: [
+          [1, 2, 3, 4],
+          [5, 6, 7, 8],
+          [9, 10, 11, 12],
+          [13, 14, 15, 16],
+          [17, 18, 19, 20],
+        ],
+        openingOdds: [
+          [1, 2, 3, 4, 5],
+          [1, 2, 3, 4, 5],
+          [1, 2, 3, 4, 5],
+          [1, 2, 3, 4, 5],
+          [1, 2, 3, 4, 5],
+        ],
+        currentOdds: [
+          [1, 2, 3, 4, 5],
+          [1, 2, 3, 4, 5],
+          [1, 2, 3, 4, 5],
+          [1, 2, 3, 4, 5],
+          [1, 2, 3, 4, 5],
+        ],
+        foods: [
+          [1, 2, 3, 4],
+          [5, 6, 7, 8],
+          [9, 10, 11, 12],
+          [13, 14, 15, 16],
+          [17, 18, 19, 20],
+        ],
+        winners: [],
+      },
+      currentSelectedRound: 8000,
+      currentRound: 8000,
+      advanced: {
+        bigBrain: false,
+        faDetails: false,
+        oddsTimeline: false,
+        customOddsMode: false,
+        useLogitModel: false,
+      },
+      customOdds: null,
+      customProbs: null,
+      viewMode: false,
+      useWebDomain: false,
+      tableMode: 'normal',
+    };
+    const bets: Bet = new Map([[1, [1, 1, 1, 1, 1]]]);
+    const betAmounts: BetAmount = new Map([[1, 50]]);
+
+    const result = calculateRoundData(roundState, bets, betAmounts);
+
+    expect(result.calculated).toBe(true);
+    expect(result.odds).toEqual(roundState.roundData.currentOdds);
+    expect(result.betBinaries.get(1)).toBeGreaterThan(0);
+    expect(result.payoutTables.odds.length).toBeGreaterThan(0);
+    expect(result.payoutTables.winnings.length).toBeGreaterThan(0);
+    expect(result.totalEnabledBets).toBe(1);
+    expect(result.totalBetAmounts).toBe(50);
+  });
+});
+
+describe('calculateBetMaps', () => {
+  it('returns empty maps when odds is an empty array', () => {
+    const result = calculateBetMaps(
+      [
+        [0, 1],
+        [0, 1],
+      ],
+      [],
+      null,
+      0,
+    );
+    expect(result.betCaps.size).toBe(0);
+    expect(result.betOdds.size).toBe(0);
+    expect(result.pirateCombos.size).toBe(0);
+  });
+
+  it('computes betOdds/betCaps for a small pirateChoices cartesian product without pirateCombos', () => {
+    const pirateChoices = [
+      [0, 1],
+      [0, 1],
+    ];
+    const odds = [[0, 2], [0, 4], [], [], []];
+
+    const result = calculateBetMaps(pirateChoices, odds, null, 0, {
+      includePirateCombos: false,
+    });
+
+    // [0,0] produces betBinary 0 and is skipped; the other 3 combos are kept.
+    expect(result.betOdds.size).toBe(3);
+    expect(result.betCaps.size).toBe(3);
+    expect(result.pirateCombos.size).toBe(0);
+  });
+
+  it('also computes pirateCombos when includePirateCombos is true', () => {
+    const pirateChoices = [
+      [0, 1],
+      [0, 1],
+    ];
+    const odds = [[0, 2], [0, 4], [], [], []];
+    const probabilities = [[0, 0.5], [0, 0.6], [], [], []];
+
+    const result = calculateBetMaps(pirateChoices, odds, probabilities, 0, {
+      includePirateCombos: true,
+    });
+
+    expect(result.betOdds.size).toBe(3);
+    expect(result.pirateCombos.size).toBe(3);
+
+    // arena0=pirate1(odds 2), arena1=pirate1(odds 4) => betBinary for [1,1]
+    const binaryBothSelected = computePiratesBinary([1, 1]);
+    expect(result.betOdds.get(binaryBothSelected)).toBe(8); // 2 * 4
+    expect(result.pirateCombos.get(binaryBothSelected)).toBeCloseTo(2.4, 9); // 8 * (0.5*0.6)
+  });
+
+  it('applies the maxBet > 0 branch when computing pirateCombos', () => {
+    const pirateChoices = [
+      [0, 1],
+      [0, 1],
+    ];
+    const odds = [[0, 2], [0, 4], [], [], []];
+    const probabilities = [[0, 0.5], [0, 0.6], [], [], []];
+
+    const result = calculateBetMaps(pirateChoices, odds, probabilities, 1000, {
+      includePirateCombos: true,
+    });
+
+    const binaryBothSelected = computePiratesBinary([1, 1]);
+    // totalOdds=8, betCap=ceil(1_000_000/8)=125000, maxCap=min(125000,1000)=1000,
+    // winnings=min(1000*8,1_000_000)=8000, winChance=0.5*0.6=0.3
+    // pirateCombos = ((0.3*8000)/1000 - 1) * 1000 = 1400
+    expect(result.pirateCombos.get(binaryBothSelected)).toBeCloseTo(1400, 6);
   });
 });

--- a/src/app/utils/__tests__/betUtils.test.ts
+++ b/src/app/utils/__tests__/betUtils.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import {
+  generateBetLinkUrl,
+  openBetLinkInNewTab,
+  getOrdinalSuffix,
+  filterChangesByArenaPirate,
+} from '../betUtils';
+
+describe('generateBetLinkUrl', () => {
+  const pirates = [
+    [101, 102, 103, 104],
+    [105, 106, 107, 108],
+    [109, 110, 111, 112],
+    [113, 114, 115, 116],
+    [117, 118, 119, 120],
+  ];
+
+  it('builds the exact query string for a sample bet', () => {
+    const url = generateBetLinkUrl([1, 2, 0, 0, 0], 500, 6, 3000, pirates);
+    expect(url).toBe(
+      'https://www.neopets.com/pirates/process_foodclub.phtml?winner1=101&winner2=106&matches[]=1&matches[]=2&bet_amount=500&total_odds=6&winnings=3000&type=bet',
+    );
+  });
+
+  it('skips winnerN and matches[] entries for zero positions', () => {
+    const url = generateBetLinkUrl([0, 0, 3, 0, 0], 100, 4, 400, pirates);
+    expect(url).not.toContain('winner1=');
+    expect(url).not.toContain('winner2=');
+    expect(url).not.toContain('winner4=');
+    expect(url).not.toContain('winner5=');
+    expect(url).toContain('winner3=111');
+    expect(url).toContain('matches[]=3');
+    expect(url).not.toContain('matches[]=1');
+  });
+
+  it('produces no winner/matches entries for an all-zero bet', () => {
+    const url = generateBetLinkUrl([0, 0, 0, 0, 0], 100, 1, 100, pirates);
+    expect(url).toBe(
+      'https://www.neopets.com/pirates/process_foodclub.phtml?bet_amount=100&total_odds=1&winnings=100&type=bet',
+    );
+  });
+});
+
+describe('getOrdinalSuffix', () => {
+  it.each([
+    [1, 'st'],
+    [2, 'nd'],
+    [3, 'rd'],
+    [4, 'th'],
+    [11, 'th'],
+    [12, 'th'],
+    [13, 'th'],
+    [21, 'st'],
+    [22, 'nd'],
+    [23, 'rd'],
+    [101, 'st'],
+    [111, 'th'],
+  ])('returns "%s" -> "%s"', (num, expected) => {
+    expect(getOrdinalSuffix(num)).toBe(expected);
+  });
+});
+
+interface TestChange {
+  arena: number;
+  pirate: number;
+  id: string;
+}
+
+describe('filterChangesByArenaPirate', () => {
+  it('returns an empty array for an empty input', () => {
+    expect(filterChangesByArenaPirate<TestChange>([], 0, 0)).toEqual([]);
+  });
+
+  it('returns an empty array when nothing matches', () => {
+    const changes: TestChange[] = [{ arena: 1, pirate: 1, id: 'a' }];
+    expect(filterChangesByArenaPirate(changes, 2, 3)).toEqual([]);
+  });
+
+  it('excludes entries that match arena only (pirate mismatch)', () => {
+    const changes: TestChange[] = [{ arena: 2, pirate: 5, id: 'arena-only' }];
+    // pirateIndex 2 (0-based) is compared against change.pirate === 3
+    expect(filterChangesByArenaPirate(changes, 2, 2)).toEqual([]);
+  });
+
+  it('excludes entries that match pirate only (arena mismatch)', () => {
+    const changes: TestChange[] = [{ arena: 9, pirate: 3, id: 'pirate-only' }];
+    expect(filterChangesByArenaPirate(changes, 2, 2)).toEqual([]);
+  });
+
+  it('returns only entries matching both arena and the 1-based pirate', () => {
+    const changes: TestChange[] = [
+      { arena: 1, pirate: 1, id: 'a' },
+      { arena: 2, pirate: 5, id: 'b' },
+      { arena: 2, pirate: 3, id: 'c' },
+    ];
+    const result = filterChangesByArenaPirate(changes, 2, 2);
+    expect(result).toEqual([{ arena: 2, pirate: 3, id: 'c' }]);
+  });
+});
+
+describe('openBetLinkInNewTab', () => {
+  const originalUserAgent = navigator.userAgent;
+  let dispatchSpy: ReturnType<typeof vi.spyOn>;
+  let openSpy: ReturnType<typeof vi.spyOn>;
+  let capturedHref: string | undefined;
+  let capturedTarget: string | undefined;
+  let capturedEvent: MouseEvent | undefined;
+
+  const setUserAgent = (ua: string): void => {
+    Object.defineProperty(navigator, 'userAgent', { value: ua, configurable: true });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedHref = undefined;
+    capturedTarget = undefined;
+    capturedEvent = undefined;
+    openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    dispatchSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'dispatchEvent')
+      .mockImplementation(function (this: HTMLAnchorElement, event: Event) {
+        capturedHref = this.href;
+        capturedTarget = this.target;
+        capturedEvent = event as MouseEvent;
+        return true;
+      });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: originalUserAgent,
+      configurable: true,
+    });
+    dispatchSpy.mockRestore();
+    openSpy.mockRestore();
+  });
+
+  it('dispatches a click event with ctrlKey on desktop Windows', () => {
+    setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36');
+
+    openBetLinkInNewTab('https://example.com/bet');
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(capturedHref).toBe('https://example.com/bet');
+    expect(capturedTarget).toBe('_blank');
+    expect(capturedEvent?.ctrlKey).toBe(true);
+    expect(capturedEvent?.metaKey).toBe(false);
+  });
+
+  it('dispatches a click event with metaKey on desktop macOS', () => {
+    setUserAgent(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)',
+    );
+
+    openBetLinkInNewTab('https://example.com/bet-mac');
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(capturedHref).toBe('https://example.com/bet-mac');
+    expect(capturedEvent?.ctrlKey).toBe(false);
+    expect(capturedEvent?.metaKey).toBe(true);
+  });
+
+  it('falls back to window.open on Android (mobile)', () => {
+    setUserAgent('Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 Mobile');
+
+    openBetLinkInNewTab('https://example.com/bet-mobile');
+
+    expect(openSpy).toHaveBeenCalledWith('https://example.com/bet-mobile', '_blank');
+    expect(dispatchSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to window.open on a generic "Mobi" user agent', () => {
+    setUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Mobi/15E148');
+
+    openBetLinkInNewTab('https://example.com/bet-mobi');
+
+    expect(openSpy).toHaveBeenCalledWith('https://example.com/bet-mobi', '_blank');
+    expect(dispatchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/utils/__tests__/duplicateBetColors.test.ts
+++ b/src/app/utils/__tests__/duplicateBetColors.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+
+import { DUPLICATE_BET_COLOR_PALETTE, computeDuplicateBetGroupColors } from '../duplicateBetColors';
+
+describe('computeDuplicateBetGroupColors', () => {
+  it('returns an empty map for an empty input', () => {
+    const result = computeDuplicateBetGroupColors(new Map());
+    expect(result.size).toBe(0);
+  });
+
+  it('assigns no colors when no binaries are duplicated', () => {
+    const betBinaries = new Map([
+      [1, 100],
+      [2, 200],
+      [3, 300],
+    ]);
+    const result = computeDuplicateBetGroupColors(betBinaries);
+    expect(result.size).toBe(0);
+  });
+
+  it('assigns a color when 2+ bets share the same non-zero binary', () => {
+    const betBinaries = new Map([
+      [1, 100],
+      [2, 100],
+      [3, 300],
+    ]);
+    const result = computeDuplicateBetGroupColors(betBinaries);
+    expect(result.size).toBe(1);
+    expect(result.get(100)).toBe(DUPLICATE_BET_COLOR_PALETTE[0]);
+  });
+
+  it('assigns a color when 3 bets share the same non-zero binary', () => {
+    const betBinaries = new Map([
+      [1, 100],
+      [2, 100],
+      [3, 100],
+    ]);
+    const result = computeDuplicateBetGroupColors(betBinaries);
+    expect(result.size).toBe(1);
+    expect(result.get(100)).toBe(DUPLICATE_BET_COLOR_PALETTE[0]);
+  });
+
+  it('always excludes binary === 0 entries, even when duplicated', () => {
+    const betBinaries = new Map([
+      [1, 0],
+      [2, 0],
+      [3, 0],
+    ]);
+    const result = computeDuplicateBetGroupColors(betBinaries);
+    expect(result.size).toBe(0);
+    expect(result.has(0)).toBe(false);
+  });
+
+  it('excludes binary 0 duplicates while still coloring other duplicate groups', () => {
+    const betBinaries = new Map([
+      [1, 0],
+      [2, 0],
+      [3, 500],
+      [4, 500],
+    ]);
+    const result = computeDuplicateBetGroupColors(betBinaries);
+    expect(result.size).toBe(1);
+    expect(result.has(0)).toBe(false);
+    expect(result.get(500)).toBe(DUPLICATE_BET_COLOR_PALETTE[0]);
+  });
+
+  it('assigns distinct colors to multiple duplicate groups in insertion order', () => {
+    const betBinaries = new Map([
+      [1, 100],
+      [2, 100],
+      [3, 200],
+      [4, 200],
+    ]);
+    const result = computeDuplicateBetGroupColors(betBinaries);
+    expect(result.size).toBe(2);
+    expect(result.get(100)).toBe(DUPLICATE_BET_COLOR_PALETTE[0]);
+    expect(result.get(200)).toBe(DUPLICATE_BET_COLOR_PALETTE[1]);
+  });
+
+  it('wraps color index around the palette when there are more than 7 duplicate groups', () => {
+    const entries: [number, number][] = [];
+    // 8 duplicate groups (binaries 1000..1007), each with 2 bets sharing that binary.
+    for (let group = 0; group < 8; group++) {
+      const binary = 1000 + group;
+      entries.push([group * 2 + 1, binary]);
+      entries.push([group * 2 + 2, binary]);
+    }
+    const betBinaries = new Map(entries);
+    const result = computeDuplicateBetGroupColors(betBinaries);
+    expect(result.size).toBe(8);
+    expect(DUPLICATE_BET_COLOR_PALETTE).toHaveLength(7);
+    // The 8th group (index 7) should wrap back around to palette index 0.
+    expect(result.get(1000)).toBe(DUPLICATE_BET_COLOR_PALETTE[0]);
+    expect(result.get(1006)).toBe(DUPLICATE_BET_COLOR_PALETTE[6]);
+    expect(result.get(1007)).toBe(DUPLICATE_BET_COLOR_PALETTE[0]);
+  });
+});

--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -3,6 +3,7 @@ import React, { ReactElement } from 'react';
 import { vi } from 'vitest';
 
 import { Provider } from '../components/ui/provider';
+import type { RoundCalculationResult, RoundData } from '../types';
 
 // Custom render function that includes Chakra UI provider
 const AllTheProviders = ({ children }: { children: React.ReactNode }): ReactElement => (
@@ -61,3 +62,294 @@ export const waitFor = (fn: () => void | Promise<void>, timeout = 5000): Promise
 
     check();
   });
+
+// Fixture builder for RoundData, matching the shape used by the round-fetching tests
+// (see hashchange.test.ts). Overrides are merged shallowly on top of the defaults.
+export const makeRoundData = (overrides: Partial<RoundData> = {}): RoundData => ({
+  round: 8000,
+  pirates: [
+    [1, 2, 3, 4],
+    [5, 6, 7, 8],
+    [9, 10, 11, 12],
+    [13, 14, 15, 16],
+    [17, 18, 19, 20],
+  ],
+  openingOdds: [
+    [1, 2, 3, 4, 5],
+    [1, 2, 3, 4, 5],
+    [1, 2, 3, 4, 5],
+    [1, 2, 3, 4, 5],
+    [1, 2, 3, 4, 5],
+  ],
+  currentOdds: [
+    [1, 2, 3, 4, 5],
+    [1, 2, 3, 4, 5],
+    [1, 2, 3, 4, 5],
+    [1, 2, 3, 4, 5],
+    [1, 2, 3, 4, 5],
+  ],
+  foods: [
+    [1, 2, 3, 4],
+    [5, 6, 7, 8],
+    [9, 10, 11, 12],
+    [13, 14, 15, 16],
+    [17, 18, 19, 20],
+  ],
+  winners: [],
+  ...overrides,
+});
+
+// Resets useBetStore and useRoundStore to a clean, minimal known state. Generalizes the
+// inline beforeEach pattern used by hashchange.test.ts so future test files don't have
+// to duplicate it.
+//
+// The store modules are imported dynamically (rather than at the top of this file) so that
+// merely importing test/utils.tsx (which nearly every test file does, for `render`/`screen`)
+// does not eagerly load the real Zustand stores. Eagerly loading them breaks test files that
+// partially mock sibling modules (e.g. `vi.mock('../util', ...)`), since those real stores
+// import from those same modules at their own top level.
+export const resetStores = async (): Promise<void> => {
+  const [
+    { useBetStore },
+    { useRoundStore },
+    { defaultRoundData },
+    { makeEmptyBets, makeEmptyBetAmounts },
+  ] = await Promise.all([
+    import('../app/stores/betStore'),
+    import('../app/stores/roundStore'),
+    import('../app/constants'),
+    import('../app/util'),
+  ]);
+
+  useRoundStore.setState({
+    currentSelectedRound: 8000,
+    currentRound: 8000,
+    isInitializing: false,
+    roundData: defaultRoundData,
+  });
+  useBetStore.setState({
+    currentBet: 0,
+    allBets: new Map([[0, makeEmptyBets(10)]]),
+    allBetAmounts: new Map([[0, makeEmptyBetAmounts(10)]]),
+    allNames: new Map([[0, 'Test Set']]),
+  });
+};
+
+const emptyCalculationsMock: RoundCalculationResult = {
+  calculated: false,
+  legacyProbabilities: { min: [], std: [], max: [], used: [] },
+  logitProbabilities: { prob: [], used: [] },
+  usedProbabilities: [],
+  pirateFAs: new Map(),
+  arenaRatios: [],
+  betOdds: new Map(),
+  betPayoffs: new Map(),
+  betProbabilities: new Map(),
+  betExpectedRatios: new Map(),
+  betNetExpected: new Map(),
+  betMaxBets: new Map(),
+  betBinaries: new Map(),
+  odds: [],
+  payoutTables: { odds: [], winnings: [] },
+  winningBetBinary: 0,
+  totalBetAmounts: 0,
+  totalBetExpectedRatios: 0,
+  totalBetNetExpected: 0,
+  totalWinningPayoff: 0,
+  totalWinningOdds: 0,
+  totalEnabledBets: 0,
+};
+
+// NOTE: `vi.mock` factories are hoisted above imports by Vitest, so this object cannot be
+// passed in or customized at call time -- it is a static set of sane defaults only.
+// Future test files should spread it and override specific keys, e.g.:
+//   vi.mock('../../stores', () => ({ ...defaultStoreMocks, useSelectedRound: () => 1234 }))
+export const defaultStoreMocks = {
+  useBetStore: { getState: (): Record<string, never> => ({}) },
+  useRoundStore: { getState: (): Record<string, never> => ({}) },
+  setToastFunction: vi.fn(),
+
+  // Bet hooks
+  useCurrentBet: (): number => 0,
+  useAllBets: (): Map<number, Map<number, number[]>> => new Map(),
+  useAllBetAmounts: (): Map<number, Map<number, number>> => new Map(),
+  useAllBetSetNames: (): Map<number, string> => new Map(),
+  useCurrentBetName: (): string => 'Test Set',
+  useCurrentBets: (): Map<number, number[]> => new Map(),
+  useCurrentBetAmounts: (): Map<number, number> => new Map(),
+  useBetCount: (): number => 0,
+  useBetSetCount: (): number => 0,
+  useHasAnyBets: (): boolean => false,
+  useHasAnyBetsAnywhere: (): boolean => false,
+  useSetCurrentBet: (): ((value: number) => void) => vi.fn(),
+  useAddNewSet: (): ((
+    name: string,
+    bets: Map<number, number[]>,
+    betAmounts: Map<number, number>,
+    replace?: boolean,
+  ) => void) => vi.fn(),
+  useDeleteBetSet: (): ((index: number) => void) => vi.fn(),
+  useSwapBets: (): ((uiIndex1: number, uiIndex2: number) => void) => vi.fn(),
+  useUpdatePirate: (): ((betIndex: number, arenaIndex: number, pirateIndex: number) => void) =>
+    vi.fn(),
+  useSwapPiratesForAllBets: (): ((
+    arenaIndex: number,
+    pirateIndexA: number,
+    pirateIndexB: number,
+  ) => void) => vi.fn(),
+  useUpdateBetAmount: (): ((betIndex: number, amount: number) => void) => vi.fn(),
+  useUpdateBetAmounts: (): ((updates: Array<{ betIndex: number; amount: number }>) => void) =>
+    vi.fn(),
+  useSetAllBets: (): ((bets: Map<number, Map<number, number[]>>) => void) => vi.fn(),
+  useSetAllBetAmounts: (): ((amounts: Map<number, Map<number, number>>) => void) => vi.fn(),
+  useClearAllBets: (): (() => void) => vi.fn(),
+
+  // Round data hooks
+  useRoundData: (): RoundData => makeRoundData(),
+  useCurrentRound: (): number => 8000,
+  useSelectedRound: (): number => 8000,
+  useIsLoading: (): boolean => false,
+  usePirates: (): number[][] => [],
+  useFoods: (): number[][] => [],
+  useOpeningOdds: (): number[][] => [],
+  useCurrentOdds: (): number[][] => [],
+  useChanges: (): RoundData['changes'] => [],
+  useWinners: (): number[] | undefined => [],
+  useTimestamp: (): string | undefined => '',
+  useLastChange: (): string | undefined => '',
+  useHasRoundWinners: (): boolean => false,
+  useRoundWinnersBinary: (): number => 0,
+
+  // Settings
+  useTableMode: (): string => '',
+  useBetSetPosition: (): 'above' | 'below' | 'left' | 'right' => 'below',
+  useViewMode: (): boolean => false,
+  useUseWebDomain: (): boolean => false,
+  useBigBrain: (): boolean => false,
+  useFaDetails: (): boolean => false,
+  useCustomOddsMode: (): boolean => false,
+  useOddsTimeline: (): boolean => false,
+  useLogitModelSetting: (): boolean => false,
+  useCustomOdds: (): number[][] | null => null,
+  useCustomProbs: (): number[][] | null => null,
+
+  // Setting actions
+  useUpdateSelectedRound: (): ((round: number) => void) => vi.fn(),
+  useSetTableMode: (): ((mode: string) => void) => vi.fn(),
+  useSetBetSetPosition: (): ((position: 'above' | 'below' | 'left' | 'right') => void) => vi.fn(),
+  useSetViewMode: (): ((viewMode: boolean) => void) => vi.fn(),
+  useSetUseWebDomain: (): ((useWebDomain: boolean) => void) => vi.fn(),
+  useToggleBigBrain: (): (() => void) => vi.fn(),
+  useToggleFaDetails: (): (() => void) => vi.fn(),
+  useToggleOddsTimeline: (): (() => void) => vi.fn(),
+  useToggleCustomOddsMode: (): (() => void) => vi.fn(),
+  useToggleUseLogitModel: (): (() => void) => vi.fn(),
+  useMaxBet: (): number => 0,
+  useSetMaxBet: (): ((maxBet: number) => void) => vi.fn(),
+  useSetCustomOdds: (): ((odds: number[][]) => void) => vi.fn(),
+  useSetCustomProbs: (): ((probs: number[][]) => void) => vi.fn(),
+  useInitializeRoundData: (): (() => void) => vi.fn(),
+
+  // Calculation hooks
+  useCalculations: (): RoundCalculationResult => emptyCalculationsMock,
+  useIsCalculated: (): boolean => false,
+  useBetOdds: (): Map<number, number> => new Map(),
+  useBetPayoffs: (): Map<number, number> => new Map(),
+  useBetProbabilities: (): Map<number, number> => new Map(),
+  useBetBinaries: (): Map<number, number> => new Map(),
+  useBetExpectedRatios: (): Map<number, number> => new Map(),
+  useBetNetExpected: (): Map<number, number> => new Map(),
+  useBetMaxBets: (): Map<number, number> => new Map(),
+  useTotalBetAmounts: (): number => 0,
+  useTotalBetExpectedRatios: (): number => 0,
+  useTotalBetNetExpected: (): number => 0,
+  useTotalWinningOdds: (): number => 0,
+  useTotalWinningPayoff: (): number => 0,
+  useTotalEnabledBets: (): number => 0,
+  useWinningBetBinary: (): number => 0,
+  useArenaRatios: (): number[] => [],
+  useUsedProbabilities: (): number[][] => [],
+  useLegacyProbabilities: (): {
+    min: number[][];
+    std: number[][];
+    max: number[][];
+    used: number[][];
+  } => ({
+    min: [],
+    std: [],
+    max: [],
+    used: [],
+  }),
+  useLogitProbabilities: (): { prob: number[][]; used: number[][] } => ({ prob: [], used: [] }),
+  usePirateFAs: (): Map<number, number[][]> => new Map(),
+  usePayoutTables: (): {
+    odds: Array<{ value: number; probability: number; cumulative: number; tail: number }>;
+    winnings: Array<{ value: number; probability: number; cumulative: number; tail: number }>;
+  } => ({ odds: [], winnings: [] }),
+
+  // Derived/computed hooks
+  useBetLine: (): number[] => [0, 0, 0, 0, 0],
+  useBetAmount: (): number => 0,
+  useIsPirateSelected: (): boolean => false,
+  useBetOddsValue: (): number => 0,
+  useBetPayoffValue: (): number => 0,
+  useBetProbabilityValue: (): number => 0,
+  useBetBinaryValue: (): number => 0,
+  useBetExpectedRatioValue: (): number => 0,
+  useBetNetExpectedValue: (): number => 0,
+  useBetMaxBetValue: (): number => 0,
+  usePirateForArena: (): number | undefined => undefined,
+  useFoodForArena: (): number | undefined => undefined,
+  useOpeningOddsValue: (): number | undefined => undefined,
+  useCurrentOddsValue: (): number | undefined => undefined,
+  useCustomOddsValue: (): number | undefined => undefined,
+  useCustomProbsValue: (): number | undefined => undefined,
+  useUsedProbabilityValue: (): number => 0,
+  useLogitProbabilityValue: (): number => 0,
+  useLegacyProbabilityMin: (): number => 0,
+  useLegacyProbabilityMax: (): number => 0,
+  useLegacyProbabilityStd: (): number => 0,
+  usePirateFA: (): number => 0,
+
+  // Legacy aliases (kept as separate keys since vi.mock replaces the whole module)
+  useCalculationsStatus: (): boolean => false,
+  useHasRoundData: (): boolean => true,
+  useWinnersBinary: (): number => 0,
+  useRoundWinners: (): number[] | undefined => [],
+  useBetLineSpecific: (): number[] => [0, 0, 0, 0, 0],
+  useSpecificBetAmount: (): number => 0,
+  useSpecificBetOdds: (): number => 0,
+  useSpecificBetPayoff: (): number => 0,
+  useSpecificBetProbability: (): number => 0,
+  useSpecificBetBinary: (): number => 0,
+  useSpecificBetExpectedRatio: (): number => 0,
+  useSpecificBetNetExpected: (): number => 0,
+  useSpecificBetMaxBet: (): number => 0,
+  usePirateId: (): number | undefined => undefined,
+  usePiratesForArena: (): number[] | undefined => undefined,
+  useFoodsForArena: (): number[] | undefined => undefined,
+  useTimestampValue: (): string | undefined => '',
+  useUpdateSinglePirate: (): ((
+    betIndex: number,
+    arenaIndex: number,
+    pirateIndex: number,
+  ) => void) => vi.fn(),
+  useUpdateSingleBetAmount: (): ((betIndex: number, amount: number) => void) => vi.fn(),
+  useBatchUpdateBetAmounts: (): ((updates: Array<{ betIndex: number; amount: number }>) => void) =>
+    vi.fn(),
+  useStableUsedProbability: (): number => 0,
+  useStableLogitProbability: (): number => 0,
+  useStableLegacyProbabilityMin: (): number => 0,
+  useStableLegacyProbabilityMax: (): number => 0,
+  useStableLegacyProbabilityStd: (): number => 0,
+  useStablePirateFA: (): number => 0,
+  useOptimizedBetAmount: (): number => 0,
+  useAllBetsForURLData: (): Map<number, Map<number, number[]>> => new Map(),
+  useAllBetAmountsForURLData: (): Map<number, Map<number, number>> => new Map(),
+  useCurrentBetForURL: (): number => 0,
+  useOptimizedBetsForIndex: (): Map<number, number[]> => new Map(),
+  useOptimizedBetAmountsForIndex: (): Map<number, number> => new Map(),
+  useRoundPirates: (): number[][] => [],
+  useRoundOpeningOdds: (): number[][] => [],
+  useRoundCurrentOdds: (): number[][] => [],
+};


### PR DESCRIPTION
## Summary
- Phase 1 of the test-coverage expansion effort (Phase 0: #899, shared fixtures - this branch includes that commit and should be merged after/rebased once #899 lands).
- Adds full test coverage for src/app/maths.ts (the core probability/payout math, previously untested), src/app/utils/betUtils.ts, and the new src/app/utils/duplicateBetColors.ts.
- Closes previously-untested gaps in the existing src/app/__tests__/util.test.ts: getTableMode, getBetSetPosition, getBigBrainMode (cookie-backed settings), makeBetValues, calculateRoundData, calculateBetMaps.

## Notes
- 85 new tests added (215 total across the 7 unit test files, up from 130).
- typecheck/lint clean on all new/changed files (pre-existing unrelated errors in AllBetsModal.tsx, GlowCard.tsx, and e2e/playwright config remain untouched).