### PR TITLE
chore: cancel in-progress CI runs on new pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main, master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test & Build


### PR DESCRIPTION
Fixes duplicate coverage comments on PRs - when a PR gets pushed to twice in quick succession, both CI runs execute in parallel and race to post a coverage comment before either one's delete-old-comments step sees the other's comment. Adding a concurrency group cancels the outdated run instead.