### PR TITLE
Add unit tests for six medium-complexity hooks

### DIFF
--- a/src/app/hooks/__tests__/useCustomValueInput.test.ts
+++ b/src/app/hooks/__tests__/useCustomValueInput.test.ts
@@ -1,0 +1,317 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import type { RoundData } from '../../../types';
+import { useRoundStore } from '../../stores/roundStore';
+import { useCustomValueInput } from '../useCustomValueInput';
+
+// Mock universal-cookie before any store imports (roundStore reads cookies at module init).
+// `vi.hoisted` is required here (rather than a plain top-level `const`) because `vi.mock`
+// factories are hoisted above all imports, and importing `roundStore` below synchronously
+// triggers cookie reads at module init time.
+const mockGetCookie = vi.hoisted(() => vi.fn());
+vi.mock('universal-cookie', () => ({
+  default: vi.fn().mockImplementation(function () {
+    return {
+      get: mockGetCookie,
+      set: vi.fn(),
+    };
+  }),
+}));
+
+// Allow betStore's lazy dynamic import of roundStore to resolve.
+async function waitForStoreInit(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 50));
+}
+
+// Builds a RoundData fixture with real (non-default) round data and varying odds across 5
+// arenas x 4 pirates, similar in shape to the fixture used in useBetManagement.test.ts.
+function makeRoundData(overrides: Partial<RoundData> = {}): RoundData {
+  return {
+    round: 8000,
+    pirates: [
+      [1, 2, 3, 4],
+      [5, 6, 7, 8],
+      [9, 10, 11, 12],
+      [13, 14, 15, 16],
+      [17, 18, 19, 20],
+    ],
+    openingOdds: [
+      [1, 2, 3, 4, 5],
+      [1, 3, 4, 5, 6],
+      [1, 2, 5, 6, 7],
+      [1, 4, 3, 7, 8],
+      [1, 5, 6, 2, 9],
+    ],
+    currentOdds: [
+      [1, 2, 3, 4, 5],
+      [1, 3, 4, 5, 6],
+      [1, 2, 5, 6, 7],
+      [1, 4, 3, 7, 8],
+      [1, 5, 6, 2, 9],
+    ],
+    foods: [
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    ],
+    winners: [0, 0, 0, 0, 0],
+    ...overrides,
+  };
+}
+
+// Seeds useRoundStore with real round data and triggers a real recalculate() so that
+// `calculations.usedProbabilities` is populated, matching the pattern used across the other
+// hook tests in this directory (see useBetManagement.test.ts's seedStores()).
+function seedRoundStore(overrides: Partial<RoundData> = {}): void {
+  const roundData = makeRoundData(overrides);
+  useRoundStore.setState({
+    roundData,
+    currentSelectedRound: roundData.round,
+    currentRound: roundData.round,
+    customOdds: null,
+    customProbs: null,
+    isInitializing: false,
+  });
+  useRoundStore.getState().recalculate();
+}
+
+describe('useCustomValueInput', () => {
+  beforeEach(async () => {
+    await waitForStoreInit();
+
+    mockGetCookie.mockReset();
+    mockGetCookie.mockReturnValue(undefined);
+
+    seedRoundStore();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('initial inputValue', () => {
+    it('initializes from originalValue when customValue is undefined (non-percent)', () => {
+      const originalValue = useRoundStore.getState().roundData.currentOdds[0]![1]!; // 2
+
+      const { result } = renderHook(() =>
+        useCustomValueInput({
+          arenaIndex: 0,
+          pirateIndex: 1,
+          type: 'odds',
+          customValue: undefined,
+          originalValue,
+          isPercent: false,
+        }),
+      );
+
+      expect(result.current.inputValue).toBe(originalValue.toString());
+    });
+
+    it('initializes from originalValue with percent conversion when isPercent is true', () => {
+      const originalValue = 0.25;
+
+      const { result } = renderHook(() =>
+        useCustomValueInput({
+          arenaIndex: 0,
+          pirateIndex: 1,
+          type: 'probs',
+          customValue: undefined,
+          originalValue,
+          isPercent: true,
+        }),
+      );
+
+      expect(result.current.inputValue).toBe('25');
+    });
+
+    it('initializes from customValue (percent-converted) when provided, overriding originalValue', () => {
+      const { result } = renderHook(() =>
+        useCustomValueInput({
+          arenaIndex: 0,
+          pirateIndex: 1,
+          type: 'probs',
+          customValue: 0.5,
+          originalValue: 0.25,
+          isPercent: true,
+        }),
+      );
+
+      expect(result.current.inputValue).toBe('50');
+    });
+  });
+
+  describe('handleChange', () => {
+    it('updates local inputValue only, without touching the store', () => {
+      const { result } = renderHook(() =>
+        useCustomValueInput({
+          arenaIndex: 0,
+          pirateIndex: 1,
+          type: 'odds',
+          customValue: undefined,
+          originalValue: 2,
+          isPercent: false,
+        }),
+      );
+
+      act(() => {
+        result.current.handleChange('99');
+      });
+
+      expect(result.current.inputValue).toBe('99');
+      expect(useRoundStore.getState().customOdds).toBeNull();
+    });
+  });
+
+  describe('handleBlur - empty input', () => {
+    it('clears only the targeted arena/pirate slot back to originalValue (odds)', () => {
+      const currentOdds = useRoundStore.getState().roundData.currentOdds;
+      const originalValue = currentOdds[0]![1]!; // 2
+      const customOddsGrid = currentOdds.map(row => row.map(value => value + 100));
+      useRoundStore.setState({ customOdds: customOddsGrid });
+
+      const { result } = renderHook(() =>
+        useCustomValueInput({
+          arenaIndex: 0,
+          pirateIndex: 1,
+          type: 'odds',
+          customValue: customOddsGrid[0]![1],
+          originalValue,
+          isPercent: false,
+        }),
+      );
+
+      expect(result.current.inputValue).toBe(customOddsGrid[0]![1]!.toString());
+
+      act(() => {
+        result.current.handleChange('');
+      });
+
+      act(() => {
+        result.current.handleBlur();
+      });
+
+      expect(result.current.inputValue).toBe(originalValue.toString());
+
+      const updatedCustomOdds = useRoundStore.getState().customOdds!;
+      expect(updatedCustomOdds[0]![1]).toBe(originalValue);
+      // Other slots must be left untouched.
+      expect(updatedCustomOdds[0]![2]).toBe(customOddsGrid[0]![2]);
+      expect(updatedCustomOdds[1]![1]).toBe(customOddsGrid[1]![1]);
+    });
+  });
+
+  describe('handleBlur - valid new value', () => {
+    it('parses and stores a percent value (divided by 100) for probs', () => {
+      const usedProbabilities = useRoundStore.getState().calculations.usedProbabilities;
+      const originalValue = usedProbabilities[0]![1]!;
+      const untouchedNeighbor = usedProbabilities[0]![2]!;
+
+      const { result } = renderHook(() =>
+        useCustomValueInput({
+          arenaIndex: 0,
+          pirateIndex: 1,
+          type: 'probs',
+          customValue: undefined,
+          originalValue,
+          isPercent: true,
+        }),
+      );
+
+      act(() => {
+        result.current.handleChange('30');
+      });
+
+      act(() => {
+        result.current.handleBlur();
+      });
+
+      const updatedCustomProbs = useRoundStore.getState().customProbs!;
+      expect(updatedCustomProbs[0]![1]).toBe(0.3);
+      expect(updatedCustomProbs[0]![2]).toBe(untouchedNeighbor);
+      expect(result.current.inputValue).toBe('30');
+    });
+
+    it('parses and stores a non-percent integer value for odds', () => {
+      const currentOdds = useRoundStore.getState().roundData.currentOdds;
+      const originalValue = currentOdds[0]![1]!; // 2
+      const untouchedNeighbor = currentOdds[1]![2]!;
+
+      const { result } = renderHook(() =>
+        useCustomValueInput({
+          arenaIndex: 0,
+          pirateIndex: 1,
+          type: 'odds',
+          customValue: undefined,
+          originalValue,
+          isPercent: false,
+        }),
+      );
+
+      act(() => {
+        result.current.handleChange('7');
+      });
+
+      act(() => {
+        result.current.handleBlur();
+      });
+
+      const updatedCustomOdds = useRoundStore.getState().customOdds!;
+      expect(updatedCustomOdds[0]![1]).toBe(7);
+      expect(updatedCustomOdds[1]![2]).toBe(untouchedNeighbor);
+      expect(result.current.inputValue).toBe('7');
+    });
+  });
+
+  describe('handleBlur - invalid input', () => {
+    it('reverts the display value and does not touch the store for non-numeric input', () => {
+      const { result } = renderHook(() =>
+        useCustomValueInput({
+          arenaIndex: 0,
+          pirateIndex: 1,
+          type: 'odds',
+          customValue: undefined,
+          originalValue: 2,
+          isPercent: false,
+        }),
+      );
+
+      act(() => {
+        result.current.handleChange('not-a-number');
+      });
+
+      act(() => {
+        result.current.handleBlur();
+      });
+
+      expect(result.current.inputValue).toBe('2');
+      expect(useRoundStore.getState().customOdds).toBeNull();
+    });
+
+    it('reverts the display value without a store update when the value is unchanged', () => {
+      const { result } = renderHook(() =>
+        useCustomValueInput({
+          arenaIndex: 0,
+          pirateIndex: 1,
+          type: 'odds',
+          customValue: undefined,
+          originalValue: 2,
+          isPercent: false,
+        }),
+      );
+
+      act(() => {
+        result.current.handleChange('2');
+      });
+
+      act(() => {
+        result.current.handleBlur();
+      });
+
+      expect(result.current.inputValue).toBe('2');
+      expect(useRoundStore.getState().customOdds).toBeNull();
+    });
+  });
+});

--- a/src/app/hooks/__tests__/useDebouncedRoundInput.test.ts
+++ b/src/app/hooks/__tests__/useDebouncedRoundInput.test.ts
@@ -1,0 +1,132 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { useDebouncedRoundInput } from '../useDebouncedRoundInput';
+
+describe('useDebouncedRoundInput', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not call onDebouncedChange before the delay elapses', () => {
+    const onChange = vi.fn();
+    renderHook(() => useDebouncedRoundInput('123', '123', 500, onChange));
+
+    act(() => {
+      vi.advanceTimersByTime(499);
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('calls onDebouncedChange with the latest value once the delay elapses', () => {
+    const onChange = vi.fn();
+    const { rerender } = renderHook(
+      ({ value, externalValue }) => useDebouncedRoundInput(value, externalValue, 500, onChange),
+      { initialProps: { value: '123', externalValue: '123' } },
+    );
+
+    rerender({ value: '456', externalValue: '123' });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('456');
+  });
+
+  it('restarts the debounce window on every value change, only firing once for the final value', () => {
+    const onChange = vi.fn();
+    const { rerender } = renderHook(
+      ({ value, externalValue }) => useDebouncedRoundInput(value, externalValue, 500, onChange),
+      { initialProps: { value: '1', externalValue: '1' } },
+    );
+
+    rerender({ value: '12', externalValue: '1' });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    rerender({ value: '123', externalValue: '1' });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    // Only 300ms elapsed since the last change so far; the debounce should not have fired yet.
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('123');
+  });
+
+  it('cancels a pending debounce for a stale user-typed value when the external value changes and the local value is resynced', () => {
+    // This mirrors RoundInput.tsx's real usage: the caller keeps a local `value` state that is
+    // resynced to the new `externalValue` via its own effect whenever the round changes
+    // externally, so the debounce that was pending for the pre-sync (stale) value must never
+    // reach onDebouncedChange -- only the resynced value's own debounce cycle should fire.
+    const onChange = vi.fn();
+    const { rerender } = renderHook(
+      ({ value, externalValue }) => useDebouncedRoundInput(value, externalValue, 500, onChange),
+      { initialProps: { value: 'stale-user-value', externalValue: 'round-1' } },
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(onChange).not.toHaveBeenCalled();
+
+    // External round change arrives, followed by the caller resyncing its local value to match.
+    rerender({ value: 'stale-user-value', externalValue: 'round-2' });
+    rerender({ value: 'round-2', externalValue: 'round-2' });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('round-2');
+  });
+
+  it('truly cancels (not just leaves running) the pending timeout when externalValue changes', () => {
+    const onChange = vi.fn();
+    const { rerender } = renderHook(
+      ({ value, externalValue }) => useDebouncedRoundInput(value, externalValue, 500, onChange),
+      { initialProps: { value: 'stale-user-value', externalValue: 'round-1' } },
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(499);
+    });
+    expect(onChange).not.toHaveBeenCalled();
+
+    // externalValue changes just 1ms before the pending timeout would have fired -- this must
+    // clear that original timeout rather than let it fire alongside a new one.
+    rerender({ value: 'stale-user-value', externalValue: 'round-2' });
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('cleans up its pending timeout on unmount without throwing', () => {
+    const onChange = vi.fn();
+    const { unmount } = renderHook(() => useDebouncedRoundInput('123', '999', 500, onChange));
+
+    expect(() => unmount()).not.toThrow();
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/hooks/__tests__/useDuplicateBets.test.ts
+++ b/src/app/hooks/__tests__/useDuplicateBets.test.ts
@@ -1,0 +1,107 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import type { Bet } from '../../../types/bets';
+import { computePiratesBinary } from '../../maths';
+import { useDuplicateBets } from '../useDuplicateBets';
+
+function makeBets(pirateArrays: number[][]): Bet {
+  const bets: Bet = new Map();
+  pirateArrays.forEach((pirates, index) => {
+    bets.set(index + 1, pirates);
+  });
+  return bets;
+}
+
+describe('useDuplicateBets', () => {
+  it('returns empty results for an empty bets map', () => {
+    const { result } = renderHook(() => useDuplicateBets(new Map()));
+
+    expect(result.current.betBinaries).toEqual([]);
+    expect(result.current.duplicateBinaries).toEqual([]);
+    expect(result.current.hasDuplicates).toBe(false);
+  });
+
+  it('finds no duplicates when all non-empty bets are unique', () => {
+    const bets = makeBets([
+      [1, 1, 1, 1, 1],
+      [2, 2, 2, 2, 2],
+      [3, 3, 3, 3, 3],
+    ]);
+
+    const { result } = renderHook(() => useDuplicateBets(bets));
+
+    expect(result.current.betBinaries).toHaveLength(3);
+    expect(result.current.duplicateBinaries).toEqual([]);
+    expect(result.current.hasDuplicates).toBe(false);
+  });
+
+  it('flags exactly one duplicate pair', () => {
+    const bets = makeBets([
+      [1, 1, 1, 1, 1],
+      [1, 1, 1, 1, 1],
+      [2, 2, 2, 2, 2],
+    ]);
+    const duplicateBinary = computePiratesBinary([1, 1, 1, 1, 1]);
+    const uniqueBinary = computePiratesBinary([2, 2, 2, 2, 2]);
+
+    const { result } = renderHook(() => useDuplicateBets(bets));
+
+    expect(result.current.hasDuplicates).toBe(true);
+    expect(result.current.duplicateBinaries).toEqual([duplicateBinary]);
+    expect(result.current.isBetDuplicate(duplicateBinary)).toBe(true);
+    expect(result.current.isBetDuplicate(uniqueBinary)).toBe(false);
+  });
+
+  it('flags all bets as duplicate when every bet is identical', () => {
+    const bets = makeBets([
+      [4, 3, 2, 1, 1],
+      [4, 3, 2, 1, 1],
+      [4, 3, 2, 1, 1],
+    ]);
+    const binary = computePiratesBinary([4, 3, 2, 1, 1]);
+
+    const { result } = renderHook(() => useDuplicateBets(bets));
+
+    expect(result.current.hasDuplicates).toBe(true);
+    // duplicateBinaries includes one entry per bet beyond the first occurrence.
+    expect(result.current.duplicateBinaries).toEqual([binary, binary]);
+    expect(result.current.isBetDuplicate(binary)).toBe(true);
+  });
+
+  it('filters out all-zero (empty) bets before comparing for duplicates', () => {
+    const bets = makeBets([
+      [0, 0, 0, 0, 0],
+      [0, 0, 0, 0, 0],
+      [1, 1, 1, 1, 1],
+    ]);
+
+    const { result } = renderHook(() => useDuplicateBets(bets));
+
+    // Both empty bets are filtered out of betBinaries entirely, leaving only the one real bet,
+    // so there is nothing left to compare and no duplicates.
+    expect(result.current.betBinaries).toHaveLength(1);
+    expect(result.current.hasDuplicates).toBe(false);
+    expect(result.current.duplicateBinaries).toEqual([]);
+  });
+
+  it('a single non-empty bet never counts as a duplicate', () => {
+    const bets = makeBets([[1, 2, 3, 4, 1]]);
+
+    const { result } = renderHook(() => useDuplicateBets(bets));
+
+    expect(result.current.betBinaries).toHaveLength(1);
+    expect(result.current.hasDuplicates).toBe(false);
+  });
+
+  it('isBetDuplicate returns false for a binary that was never seen', () => {
+    const bets = makeBets([
+      [1, 1, 1, 1, 1],
+      [1, 1, 1, 1, 1],
+    ]);
+
+    const { result } = renderHook(() => useDuplicateBets(bets));
+
+    expect(result.current.isBetDuplicate(999999)).toBe(false);
+  });
+});

--- a/src/app/hooks/__tests__/useFormattedDate.test.ts
+++ b/src/app/hooks/__tests__/useFormattedDate.test.ts
@@ -1,0 +1,102 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { formatDate } from '../../util';
+import { useFormattedDate } from '../useFormattedDate';
+
+// formatDate itself (date-fns formatting/timezone conversion logic) is already thoroughly
+// covered by src/app/__tests__/util.test.ts's `formatDate` describe block -- here we only spy
+// on it to verify this hook wires it up correctly (calls it, stores the result, and re-invokes
+// it on each interval tick), without re-testing its internals.
+vi.mock('../../util', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../util')>();
+  return {
+    ...actual,
+    formatDate: vi.fn(actual.formatDate),
+  };
+});
+
+describe('useFormattedDate', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(formatDate).mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('produces a non-empty formattedDate string for a given date', () => {
+    const { result } = renderHook(() => useFormattedDate('2024-01-15T14:30:00Z'));
+
+    expect(result.current.formattedDate).not.toBe('');
+    expect(typeof result.current.formattedDate).toBe('string');
+    expect(formatDate).toHaveBeenCalled();
+  });
+
+  it('leaves title empty when withTitle is not requested', () => {
+    const { result } = renderHook(() => useFormattedDate('2024-01-15T14:30:00Z'));
+
+    expect(result.current.title).toBe('');
+  });
+
+  it('populates title when withTitle and titleFormat are provided', () => {
+    const { result } = renderHook(() =>
+      useFormattedDate('2024-01-15T14:30:00Z', {
+        withTitle: true,
+        titleFormat: 'YYYY-MM-DD',
+      }),
+    );
+
+    expect(result.current.title).not.toBe('');
+    expect(result.current.title).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('does not populate title when withTitle is true but titleFormat is missing', () => {
+    const { result } = renderHook(() =>
+      useFormattedDate('2024-01-15T14:30:00Z', { withTitle: true }),
+    );
+
+    expect(result.current.title).toBe('');
+  });
+
+  it('does not set up a recurring interval when no interval option is given', () => {
+    renderHook(() => useFormattedDate('2024-01-15T14:30:00Z'));
+
+    const callsAfterMount = vi.mocked(formatDate).mock.calls.length;
+    expect(callsAfterMount).toBeGreaterThan(0);
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    // No interval was requested, so no additional formatDate calls should occur over time.
+    expect(vi.mocked(formatDate).mock.calls.length).toBe(callsAfterMount);
+  });
+
+  it('recomputes formattedDate on each tick when interval is provided (in seconds)', () => {
+    renderHook(() => useFormattedDate('2024-01-15T14:30:00Z', { interval: 1 }));
+
+    const callsAfterMount = vi.mocked(formatDate).mock.calls.length;
+    expect(callsAfterMount).toBeGreaterThan(0);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(vi.mocked(formatDate).mock.calls.length).toBe(callsAfterMount + 1);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(vi.mocked(formatDate).mock.calls.length).toBe(callsAfterMount + 2);
+  });
+
+  it('does not call formatDate when the date is falsy (empty string)', () => {
+    const { result } = renderHook(() => useFormattedDate(''));
+
+    expect(formatDate).not.toHaveBeenCalled();
+    expect(result.current.formattedDate).toBe('');
+  });
+});

--- a/src/app/hooks/__tests__/useProbabilities.test.ts
+++ b/src/app/hooks/__tests__/useProbabilities.test.ts
@@ -1,0 +1,148 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import type { RoundData } from '../../../types';
+import { defaultRoundData } from '../../constants';
+import { useRoundStore } from '../../stores/roundStore';
+import { useProbabilities } from '../useProbabilities';
+
+// Mock universal-cookie before any store imports (roundStore reads cookies at module init).
+// `vi.hoisted` is required here (rather than a plain top-level `const`) because `vi.mock`
+// factories are hoisted above all imports, and importing `roundStore` below synchronously
+// triggers cookie reads at module init time.
+const mockGetCookie = vi.hoisted(() => vi.fn());
+vi.mock('universal-cookie', () => ({
+  default: vi.fn().mockImplementation(function () {
+    return {
+      get: mockGetCookie,
+      set: vi.fn(),
+    };
+  }),
+}));
+
+// Allow betStore's lazy dynamic import of roundStore to resolve.
+async function waitForStoreInit(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 50));
+}
+
+// Builds a RoundData fixture with real (non-default) round data and varying odds across 5
+// arenas x 4 pirates, similar in shape to the fixture used in useBetManagement.test.ts.
+function makeRoundData(overrides: Partial<RoundData> = {}): RoundData {
+  return {
+    round: 8000,
+    pirates: [
+      [1, 2, 3, 4],
+      [5, 6, 7, 8],
+      [9, 10, 11, 12],
+      [13, 14, 15, 16],
+      [17, 18, 19, 20],
+    ],
+    openingOdds: [
+      [1, 2, 3, 4, 5],
+      [1, 3, 4, 5, 6],
+      [1, 2, 5, 6, 7],
+      [1, 4, 3, 7, 8],
+      [1, 5, 6, 2, 9],
+    ],
+    currentOdds: [
+      [1, 2, 3, 4, 5],
+      [1, 3, 4, 5, 6],
+      [1, 2, 5, 6, 7],
+      [1, 4, 3, 7, 8],
+      [1, 5, 6, 2, 9],
+    ],
+    foods: [
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    ],
+    winners: [0, 0, 0, 0, 0],
+    ...overrides,
+  };
+}
+
+describe('useProbabilities', () => {
+  beforeEach(async () => {
+    await waitForStoreInit();
+
+    mockGetCookie.mockReset();
+    mockGetCookie.mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('computes non-empty legacy and logit probability arrays for real round data', () => {
+    useRoundStore.setState({ roundData: makeRoundData() });
+
+    const { result } = renderHook(() => useProbabilities());
+
+    expect(result.current.legacyProbabilities.length).toBe(5);
+    expect(result.current.logitProbabilities.length).toBe(5);
+    expect(result.current.legacyProbabilities.every(arena => arena.length > 0)).toBe(true);
+    expect(result.current.logitProbabilities.every(arena => arena.length > 0)).toBe(true);
+  });
+
+  it('returns [] for both when roundData is falsy', () => {
+    // This hook itself guards `if (!roundData) return [];` before doing any computation,
+    // separately from computeLegacyProbabilities/computeLogitProbabilities's own internal
+    // guards -- roundData is typed as non-nullable RoundData in the store, so this is only
+    // reachable via a defensive cast, exercising that guard directly.
+    useRoundStore.setState({ roundData: null as unknown as RoundData });
+
+    const { result } = renderHook(() => useProbabilities());
+
+    expect(result.current.legacyProbabilities).toEqual([]);
+    expect(result.current.logitProbabilities).toEqual([]);
+  });
+
+  it('handles missing pirates/openingOdds distinctly per the underlying compute functions', () => {
+    // defaultRoundData has empty pirates and empty openingOdds arrays. computeLogitProbabilities
+    // early-returns `used: []` when pirates is empty, but computeLegacyProbabilities only checks
+    // openingOdds and otherwise falls back to its non-empty sentinel (5 arenas of [1, 0, 0, 0, 0]).
+    useRoundStore.setState({ roundData: defaultRoundData });
+
+    const { result } = renderHook(() => useProbabilities());
+
+    expect(result.current.logitProbabilities).toEqual([]);
+    expect(result.current.legacyProbabilities).toEqual([
+      [1, 0, 0, 0, 0],
+      [1, 0, 0, 0, 0],
+      [1, 0, 0, 0, 0],
+      [1, 0, 0, 0, 0],
+      [1, 0, 0, 0, 0],
+    ]);
+  });
+
+  it('recomputes when roundData changes', () => {
+    useRoundStore.setState({ roundData: makeRoundData() });
+
+    const { result, rerender } = renderHook(() => useProbabilities());
+    const firstLegacy = result.current.legacyProbabilities;
+
+    useRoundStore.setState({
+      roundData: makeRoundData({
+        currentOdds: [
+          [1, 8, 9, 10, 11],
+          [1, 3, 4, 5, 6],
+          [1, 2, 5, 6, 7],
+          [1, 4, 3, 7, 8],
+          [1, 5, 6, 2, 9],
+        ],
+        openingOdds: [
+          [1, 8, 9, 10, 11],
+          [1, 3, 4, 5, 6],
+          [1, 2, 5, 6, 7],
+          [1, 4, 3, 7, 8],
+          [1, 5, 6, 2, 9],
+        ],
+      }),
+    });
+    rerender();
+
+    expect(result.current.legacyProbabilities).not.toEqual(firstLegacy);
+  });
+});

--- a/src/app/hooks/__tests__/useTimelineViewState.test.ts
+++ b/src/app/hooks/__tests__/useTimelineViewState.test.ts
@@ -1,0 +1,119 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { useTimelineViewState } from '../useTimelineViewState';
+
+describe('useTimelineViewState', () => {
+  it('starts on the "overall" view when neither initial arena nor pirate is set', () => {
+    const { result } = renderHook(() =>
+      useTimelineViewState({ initialArenaId: null, initialPirateIndex: null }),
+    );
+
+    expect(result.current.view).toBe('overall');
+    expect(result.current.selectedArena).toBeNull();
+    expect(result.current.selectedPirate).toBeNull();
+  });
+
+  it('starts on the "arena" view when only an initial arena is set', () => {
+    const { result } = renderHook(() =>
+      useTimelineViewState({ initialArenaId: 2, initialPirateIndex: null }),
+    );
+
+    expect(result.current.view).toBe('arena');
+    expect(result.current.selectedArena).toBe(2);
+    expect(result.current.selectedPirate).toBeNull();
+  });
+
+  it('starts on the "pirate" view when both initial arena and pirate are set', () => {
+    const { result } = renderHook(() =>
+      useTimelineViewState({ initialArenaId: 1, initialPirateIndex: 3 }),
+    );
+
+    expect(result.current.view).toBe('pirate');
+    expect(result.current.selectedArena).toBe(1);
+    expect(result.current.selectedPirate).toEqual({ arenaId: 1, pirateIndex: 3 });
+  });
+
+  it('handleArenaClick moves to the "arena" view and sets the selected arena', () => {
+    const { result } = renderHook(() =>
+      useTimelineViewState({ initialArenaId: null, initialPirateIndex: null }),
+    );
+
+    act(() => {
+      result.current.handleArenaClick(4);
+    });
+
+    expect(result.current.view).toBe('arena');
+    expect(result.current.selectedArena).toBe(4);
+  });
+
+  it('handlePirateClick moves to the "pirate" view and sets arena + pirate', () => {
+    const { result } = renderHook(() =>
+      useTimelineViewState({ initialArenaId: null, initialPirateIndex: null }),
+    );
+
+    act(() => {
+      result.current.handlePirateClick(0, 2);
+    });
+
+    expect(result.current.view).toBe('pirate');
+    expect(result.current.selectedArena).toBe(0);
+    expect(result.current.selectedPirate).toEqual({ arenaId: 0, pirateIndex: 2 });
+  });
+
+  it('handleBackToOverall moves back to the "overall" view without clearing selection', () => {
+    const { result } = renderHook(() =>
+      useTimelineViewState({ initialArenaId: 1, initialPirateIndex: 3 }),
+    );
+
+    act(() => {
+      result.current.handleBackToOverall();
+    });
+
+    expect(result.current.view).toBe('overall');
+    // handleBackToOverall only changes `view`; selectedArena/selectedPirate are left as-is.
+    expect(result.current.selectedArena).toBe(1);
+    expect(result.current.selectedPirate).toEqual({ arenaId: 1, pirateIndex: 3 });
+  });
+
+  it('handleBackToArena moves back to the "arena" view and updates the selected arena', () => {
+    const { result } = renderHook(() =>
+      useTimelineViewState({ initialArenaId: 1, initialPirateIndex: 3 }),
+    );
+
+    act(() => {
+      result.current.handleBackToArena(2);
+    });
+
+    expect(result.current.view).toBe('arena');
+    expect(result.current.selectedArena).toBe(2);
+  });
+
+  it('supports a full navigation cycle: overall -> arena -> pirate -> arena -> overall', () => {
+    const { result } = renderHook(() =>
+      useTimelineViewState({ initialArenaId: null, initialPirateIndex: null }),
+    );
+
+    expect(result.current.view).toBe('overall');
+
+    act(() => {
+      result.current.handleArenaClick(0);
+    });
+    expect(result.current.view).toBe('arena');
+
+    act(() => {
+      result.current.handlePirateClick(0, 1);
+    });
+    expect(result.current.view).toBe('pirate');
+
+    act(() => {
+      result.current.handleBackToArena(0);
+    });
+    expect(result.current.view).toBe('arena');
+
+    act(() => {
+      result.current.handleBackToOverall();
+    });
+    expect(result.current.view).toBe('overall');
+  });
+});


### PR DESCRIPTION
## Summary
- Phase 2.2 of the test-coverage expansion effort (Phase 0: #899, Phase 1: #902, Phase 2.1: #905).
- Adds 41 tests across 6 new files covering src/app/hooks/useProbabilities.ts, useDuplicateBets.ts, useTimelineViewState.ts, useCustomValueInput.ts, useDebouncedRoundInput.ts, and useFormattedDate.ts.
- Introduces vi.useFakeTimers() to this codebase for the first time (used in the debounce and interval-driven hook tests).
- This branch is independent of the other open phase PRs (built from master with its own fixtures) so it can be reviewed/merged in any order.

## Notes
- typecheck/lint clean (same pre-existing unrelated errors as before, untouched).