### PR TITLE
fix: use fine-grained Shiki bundle to avoid shipping every language/theme

### DIFF
--- a/src/app/components/modals/RoundJsonModal.tsx
+++ b/src/app/components/modals/RoundJsonModal.tsx
@@ -12,16 +12,26 @@ import {
 } from '@chakra-ui/react';
 import * as React from 'react';
 import { FaCode } from 'react-icons/fa';
-import type { BundledLanguage, BundledTheme, HighlighterGeneric } from 'shiki';
+import type { HighlighterGeneric } from 'shiki';
 
 import { useRoundStore } from '../../stores';
 
-const shikiAdapter = createShikiAdapter<HighlighterGeneric<BundledLanguage, BundledTheme>>({
+// Uses the fine-grained core API (rather than `createHighlighter` from the
+// `shiki` package) so the bundler only includes the json language and
+// github-dark theme instead of every language/theme shiki ships.
+const shikiAdapter = createShikiAdapter<HighlighterGeneric<'json', 'github-dark'>>({
   async load() {
-    const { createHighlighter } = await import('shiki');
-    return createHighlighter({
-      langs: ['json'],
-      themes: ['github-dark'],
+    const [{ createHighlighterCore }, { createOnigurumaEngine }, json, githubDark] =
+      await Promise.all([
+        import('shiki/core'),
+        import('shiki/engine/oniguruma'),
+        import('shiki/langs/json.mjs'),
+        import('shiki/themes/github-dark.mjs'),
+      ]);
+    return createHighlighterCore({
+      langs: [json.default],
+      themes: [githubDark.default],
+      engine: createOnigurumaEngine(import('shiki/wasm')),
     });
   },
   theme: 'github-dark',


### PR DESCRIPTION
## Summary
- RoundJsonModal loaded Shiki via `createHighlighter` from the main `shiki` package, which pulls in the full-bundle registry referencing all ~690 languages and ~130 themes as lazy chunks. Even though only `json` + `github-dark` were requested at runtime, Rollup couldn't tree-shake that registry object, so every language/theme chunk was emitted into the build output and shipped to Cloudflare.
- Switched to Shiki's fine-grained `createHighlighterCore` API with direct imports of just the json language and github-dark theme, so only those get bundled.
- Verified locally: `build/assets` went from 295 files / 11 MB to 23 files / 2.4 MB, and the Round JSON modal still renders correctly with syntax highlighting.