### PR TITLE
Add unit tests for eight small utility hooks

### DIFF
--- a/src/app/hooks/__tests__/useDebouncedValue.test.ts
+++ b/src/app/hooks/__tests__/useDebouncedValue.test.ts
@@ -1,0 +1,102 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { useDebouncedValue } from '../useDebouncedValue';
+
+describe('useDebouncedValue', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the initial value immediately', () => {
+    const { result } = renderHook(() => useDebouncedValue('initial'));
+
+    expect(result.current).toBe('initial');
+  });
+
+  it('updates the debounced value after the delay elapses', () => {
+    const { result, rerender } = renderHook(({ value }) => useDebouncedValue(value, 300), {
+      initialProps: { value: 'initial' },
+    });
+
+    rerender({ value: 'updated' });
+    expect(result.current).toBe('initial');
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(result.current).toBe('updated');
+  });
+
+  it('does not update the value before the delay has fully elapsed', () => {
+    const { result, rerender } = renderHook(({ value }) => useDebouncedValue(value, 300), {
+      initialProps: { value: 'initial' },
+    });
+
+    rerender({ value: 'updated' });
+
+    act(() => {
+      vi.advanceTimersByTime(299);
+    });
+
+    expect(result.current).toBe('initial');
+  });
+
+  it('only commits the last value when changed rapidly in succession', () => {
+    const { result, rerender } = renderHook(({ value }) => useDebouncedValue(value, 300), {
+      initialProps: { value: 'a' },
+    });
+
+    rerender({ value: 'b' });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    rerender({ value: 'c' });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    rerender({ value: 'd' });
+
+    // Total elapsed since last change is only 0ms, so nothing has committed yet
+    expect(result.current).toBe('a');
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(result.current).toBe('d');
+  });
+
+  it('uses the default delay of 300ms when none is provided', () => {
+    const { result, rerender } = renderHook(({ value }) => useDebouncedValue(value), {
+      initialProps: { value: 'initial' },
+    });
+
+    rerender({ value: 'updated' });
+
+    act(() => {
+      vi.advanceTimersByTime(299);
+    });
+    expect(result.current).toBe('initial');
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe('updated');
+  });
+
+  it('does not throw when unmounted before the timeout fires', () => {
+    const { unmount } = renderHook(({ value }) => useDebouncedValue(value, 300), {
+      initialProps: { value: 'initial' },
+    });
+
+    expect(() => {
+      unmount();
+    }).not.toThrow();
+  });
+});

--- a/src/app/hooks/__tests__/useDisclosureState.test.ts
+++ b/src/app/hooks/__tests__/useDisclosureState.test.ts
@@ -1,0 +1,66 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { useDisclosureState } from '../useDisclosureState';
+
+describe('useDisclosureState', () => {
+  it('defaults isOpen to false', () => {
+    const { result } = renderHook(() => useDisclosureState());
+
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('defaults isOpen to true when defaultIsOpen is passed', () => {
+    const { result } = renderHook(() => useDisclosureState(true));
+
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it('onOpen sets isOpen to true', () => {
+    const { result } = renderHook(() => useDisclosureState());
+
+    act(() => {
+      result.current.onOpen();
+    });
+
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it('onClose sets isOpen to false', () => {
+    const { result } = renderHook(() => useDisclosureState(true));
+
+    act(() => {
+      result.current.onClose();
+    });
+
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('onToggle flips isOpen from false to true and back', () => {
+    const { result } = renderHook(() => useDisclosureState());
+
+    act(() => {
+      result.current.onToggle();
+    });
+    expect(result.current.isOpen).toBe(true);
+
+    act(() => {
+      result.current.onToggle();
+    });
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('setOpen sets isOpen to the provided boolean value', () => {
+    const { result } = renderHook(() => useDisclosureState());
+
+    act(() => {
+      result.current.setOpen(true);
+    });
+    expect(result.current.isOpen).toBe(true);
+
+    act(() => {
+      result.current.setOpen(false);
+    });
+    expect(result.current.isOpen).toBe(false);
+  });
+});

--- a/src/app/hooks/__tests__/useGetPirateBgColor.test.ts
+++ b/src/app/hooks/__tests__/useGetPirateBgColor.test.ts
@@ -1,0 +1,51 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { useGetPirateBgColor } from '../useGetPirateBgColor';
+
+describe('useGetPirateBgColor', () => {
+  it('returns nfc-blue for odds 3, 4, and 5', () => {
+    const { result } = renderHook(() => useGetPirateBgColor());
+
+    expect(result.current(3)).toBe('nfc-blue');
+    expect(result.current(4)).toBe('nfc-blue');
+    expect(result.current(5)).toBe('nfc-blue');
+  });
+
+  it('returns nfc-orange for odds 6, 7, 8, and 9', () => {
+    const { result } = renderHook(() => useGetPirateBgColor());
+
+    expect(result.current(6)).toBe('nfc-orange');
+    expect(result.current(7)).toBe('nfc-orange');
+    expect(result.current(8)).toBe('nfc-orange');
+    expect(result.current(9)).toBe('nfc-orange');
+  });
+
+  it('returns nfc-red for odds 10, 11, 12, and 13', () => {
+    const { result } = renderHook(() => useGetPirateBgColor());
+
+    expect(result.current(10)).toBe('nfc-red');
+    expect(result.current(11)).toBe('nfc-red');
+    expect(result.current(12)).toBe('nfc-red');
+    expect(result.current(13)).toBe('nfc-red');
+  });
+
+  it('returns nfc-green for any other odds value', () => {
+    const { result } = renderHook(() => useGetPirateBgColor());
+
+    expect(result.current(0)).toBe('nfc-green');
+    expect(result.current(1)).toBe('nfc-green');
+    expect(result.current(2)).toBe('nfc-green');
+    expect(result.current(14)).toBe('nfc-green');
+  });
+
+  it('returns a stable function reference across re-renders', () => {
+    const { result, rerender } = renderHook(() => useGetPirateBgColor());
+
+    const firstFn = result.current;
+    rerender();
+    const secondFn = result.current;
+
+    expect(firstFn).toBe(secondFn);
+  });
+});

--- a/src/app/hooks/__tests__/useInterval.test.ts
+++ b/src/app/hooks/__tests__/useInterval.test.ts
@@ -1,0 +1,80 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { useInterval } from '../useInterval';
+
+describe('useInterval', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('calls the callback repeatedly at the given interval', () => {
+    const callback = vi.fn();
+    renderHook(() => useInterval(callback, 1000));
+
+    vi.advanceTimersByTime(1000);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(2000);
+    expect(callback).toHaveBeenCalledTimes(3);
+  });
+
+  it('never fires the callback when delay is null', () => {
+    const callback = vi.fn();
+    renderHook(() => useInterval(callback, null));
+
+    vi.advanceTimersByTime(5000);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('resets the interval cadence when delay changes', () => {
+    const callback = vi.fn();
+    const { rerender } = renderHook(({ delay }) => useInterval(callback, delay), {
+      initialProps: { delay: 1000 },
+    });
+
+    vi.advanceTimersByTime(1000);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    rerender({ delay: 500 });
+
+    vi.advanceTimersByTime(500);
+    expect(callback).toHaveBeenCalledTimes(2);
+
+    vi.advanceTimersByTime(500);
+    expect(callback).toHaveBeenCalledTimes(3);
+  });
+
+  it('invokes the latest callback without restarting the timer when only the callback changes', () => {
+    const firstCallback = vi.fn();
+    const secondCallback = vi.fn();
+    const { rerender } = renderHook(({ callback }) => useInterval(callback, 1000), {
+      initialProps: { callback: firstCallback },
+    });
+
+    rerender({ callback: secondCallback });
+
+    vi.advanceTimersByTime(1000);
+
+    expect(firstCallback).not.toHaveBeenCalled();
+    expect(secondCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the interval on unmount', () => {
+    const callback = vi.fn();
+    const { unmount } = renderHook(() => useInterval(callback, 1000));
+
+    vi.advanceTimersByTime(1000);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    vi.advanceTimersByTime(5000);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/hooks/__tests__/useIsRoundOver.test.ts
+++ b/src/app/hooks/__tests__/useIsRoundOver.test.ts
@@ -1,0 +1,91 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { RoundData } from '../../../types';
+import { useRoundStore } from '../../stores';
+import { useIsRoundOver } from '../useIsRoundOver';
+
+// Mock universal-cookie before any store imports
+const mockGetCookie = vi.hoisted(() => vi.fn());
+vi.mock('universal-cookie', () => ({
+  default: vi.fn().mockImplementation(function () {
+    return {
+      get: mockGetCookie,
+      set: vi.fn(),
+    };
+  }),
+}));
+
+function makeRoundData(winners: number[] | undefined): RoundData {
+  const base = {
+    round: 1,
+    pirates: [
+      [1, 2, 3, 4],
+      [5, 6, 7, 8],
+      [9, 10, 11, 12],
+      [13, 14, 15, 16],
+      [17, 18, 19, 20],
+    ],
+    openingOdds: [
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+    ],
+    currentOdds: [
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+    ],
+    foods: [
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    ],
+  };
+  return winners === undefined ? base : { ...base, winners };
+}
+
+describe('useIsRoundOver', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCookie.mockReset();
+  });
+
+  it('returns false when no winner value is greater than zero', () => {
+    useRoundStore.setState({ roundData: makeRoundData([0, 0, 0, 0, 0]) });
+
+    const { result } = renderHook(() => useIsRoundOver());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true when at least one winner value is greater than zero', () => {
+    useRoundStore.setState({ roundData: makeRoundData([1, 0, 0, 0, 0]) });
+
+    const { result } = renderHook(() => useIsRoundOver());
+
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when winners is undefined', () => {
+    useRoundStore.setState({ roundData: makeRoundData(undefined) });
+
+    const { result } = renderHook(() => useIsRoundOver());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when winners is an empty array', () => {
+    useRoundStore.setState({ roundData: makeRoundData([]) });
+
+    const { result } = renderHook(() => useIsRoundOver());
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/app/hooks/__tests__/useRoundProgress.test.ts
+++ b/src/app/hooks/__tests__/useRoundProgress.test.ts
@@ -1,0 +1,129 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { RoundData } from '../../../types';
+import { useRoundStore } from '../../stores';
+import { useRoundProgress } from '../useRoundProgress';
+
+// Mock universal-cookie before any store imports
+const mockGetCookie = vi.hoisted(() => vi.fn());
+vi.mock('universal-cookie', () => ({
+  default: vi.fn().mockImplementation(function () {
+    return {
+      get: mockGetCookie,
+      set: vi.fn(),
+    };
+  }),
+}));
+
+function makeRoundData(start: string | undefined): RoundData {
+  const base = {
+    round: 1,
+    pirates: [
+      [1, 2, 3, 4],
+      [5, 6, 7, 8],
+      [9, 10, 11, 12],
+      [13, 14, 15, 16],
+      [17, 18, 19, 20],
+    ],
+    openingOdds: [
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+    ],
+    currentOdds: [
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+    ],
+    foods: [
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    ],
+    winners: [0, 0, 0, 0, 0],
+  };
+  return start === undefined ? base : { ...base, start };
+}
+
+describe('useRoundProgress', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCookie.mockReset();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns 0 when the round has no start timestamp', () => {
+    vi.setSystemTime(new Date('2026-01-01T12:00:00Z'));
+    useRoundStore.setState({ roundData: makeRoundData(undefined), currentSelectedRound: 1 });
+
+    const { result } = renderHook(() => useRoundProgress());
+
+    expect(result.current).toBe(0);
+  });
+
+  it('returns a percentage within the 0-100 range when the round has a start timestamp', () => {
+    vi.setSystemTime(new Date('2026-01-01T18:00:00Z'));
+    useRoundStore.setState({
+      roundData: makeRoundData('2026-01-01T00:00:00Z'),
+      currentSelectedRound: 1,
+    });
+
+    const { result } = renderHook(() => useRoundProgress());
+
+    // 18 of 24 hours elapsed => 75%
+    expect(result.current).toBeCloseTo(75, 5);
+    expect(result.current).toBeGreaterThanOrEqual(0);
+    expect(result.current).toBeLessThanOrEqual(100);
+  });
+
+  it('recomputes the percentage on the 1 second interval tick', () => {
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    useRoundStore.setState({
+      roundData: makeRoundData('2026-01-01T00:00:00Z'),
+      currentSelectedRound: 1,
+    });
+
+    const { result } = renderHook(() => useRoundProgress());
+
+    expect(result.current).toBeCloseTo(0, 5);
+
+    act(() => {
+      // Account for the 1000ms that advanceTimersByTime will additionally elapse
+      vi.setSystemTime(new Date('2026-01-01T11:59:59Z'));
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(result.current).toBeCloseTo(50, 5);
+  });
+
+  it('clears the interval on unmount', () => {
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    useRoundStore.setState({
+      roundData: makeRoundData('2026-01-01T00:00:00Z'),
+      currentSelectedRound: 1,
+    });
+
+    const { result, unmount } = renderHook(() => useRoundProgress());
+
+    unmount();
+
+    act(() => {
+      vi.setSystemTime(new Date('2026-01-01T12:00:00Z'));
+      vi.advanceTimersByTime(5000);
+    });
+
+    // Value from before unmount should remain unchanged since the interval was cleared
+    expect(result.current).toBeCloseTo(0, 5);
+  });
+});

--- a/src/app/hooks/__tests__/useScrollPosition.test.ts
+++ b/src/app/hooks/__tests__/useScrollPosition.test.ts
@@ -1,0 +1,129 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { useScrollPosition } from '../useScrollPosition';
+
+function makeContainerRef(scrollTop = 0): React.RefObject<HTMLDivElement | null> {
+  return { current: { scrollTop } as HTMLDivElement };
+}
+
+describe('useScrollPosition', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('captures the scrollTop at the time saveScrollPosition is called', () => {
+    const containerRef = makeContainerRef(0);
+    const { result, rerender } = renderHook(
+      ({ shouldRestore }) => useScrollPosition(shouldRestore, containerRef),
+      {
+        initialProps: { shouldRestore: false },
+      },
+    );
+
+    if (containerRef.current) {
+      containerRef.current.scrollTop = 250;
+    }
+
+    act(() => {
+      result.current();
+    });
+
+    // Move the actual DOM position away from what was saved
+    if (containerRef.current) {
+      containerRef.current.scrollTop = 0;
+    }
+
+    // Triggering a restore should bring back the value captured at save time (250)
+    rerender({ shouldRestore: true });
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(containerRef.current?.scrollTop).toBe(250);
+  });
+
+  it('restores the saved scroll position when shouldRestore is true', () => {
+    const containerRef = makeContainerRef(250);
+    const { result, rerender } = renderHook(
+      ({ shouldRestore }) => useScrollPosition(shouldRestore, containerRef),
+      {
+        initialProps: { shouldRestore: false },
+      },
+    );
+
+    act(() => {
+      result.current();
+    });
+
+    if (containerRef.current) {
+      containerRef.current.scrollTop = 0;
+    }
+
+    rerender({ shouldRestore: true });
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(containerRef.current?.scrollTop).toBe(250);
+  });
+
+  it('does not restore the scroll position when shouldRestore is false', () => {
+    const containerRef = makeContainerRef(250);
+    const { result, rerender } = renderHook(
+      ({ shouldRestore }) => useScrollPosition(shouldRestore, containerRef),
+      {
+        initialProps: { shouldRestore: false },
+      },
+    );
+
+    act(() => {
+      result.current();
+    });
+
+    if (containerRef.current) {
+      containerRef.current.scrollTop = 0;
+    }
+
+    rerender({ shouldRestore: false });
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(containerRef.current?.scrollTop).toBe(0);
+  });
+
+  it('does not restore when the saved position is 0', () => {
+    const containerRef = makeContainerRef(0);
+    const { result, rerender } = renderHook(
+      ({ shouldRestore }) => useScrollPosition(shouldRestore, containerRef),
+      {
+        initialProps: { shouldRestore: false },
+      },
+    );
+
+    act(() => {
+      result.current();
+    });
+
+    if (containerRef.current) {
+      containerRef.current.scrollTop = 123;
+    }
+
+    rerender({ shouldRestore: true });
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    // Saved position was 0 (falsy), so restoration should be skipped
+    expect(containerRef.current?.scrollTop).toBe(123);
+  });
+});

--- a/src/app/hooks/__tests__/useSelectOnFocus.test.ts
+++ b/src/app/hooks/__tests__/useSelectOnFocus.test.ts
@@ -1,0 +1,29 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { useSelectOnFocus } from '../useSelectOnFocus';
+
+function makeFocusEvent(select: () => void): React.FocusEvent<HTMLInputElement> {
+  return { target: { select } } as unknown as React.FocusEvent<HTMLInputElement>;
+}
+
+describe('useSelectOnFocus', () => {
+  it('calls select() on the event target when invoked', () => {
+    const { result } = renderHook(() => useSelectOnFocus());
+    const select = vi.fn();
+
+    result.current(makeFocusEvent(select));
+
+    expect(select).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a stable function reference across re-renders', () => {
+    const { result, rerender } = renderHook(() => useSelectOnFocus());
+
+    const firstFn = result.current;
+    rerender();
+    const secondFn = result.current;
+
+    expect(firstFn).toBe(secondFn);
+  });
+});


### PR DESCRIPTION
## Summary
- Phase 2.3 of the test-coverage expansion effort (Phase 0: #899, Phase 1: #902, Phase 2.1: #905, Phase 2.2: #907). Completes Phase 2 (all 15 hooks in src/app/hooks now have tests).
- Adds 36 tests across 8 new files covering useDebouncedValue, useDisclosureState, useGetPirateBgColor, useInterval, useIsRoundOver, useRoundProgress, useScrollPosition, and useSelectOnFocus.
- This branch is independent of the other open phase PRs (built from master with its own fixtures) so it can be reviewed/merged in any order.

## Notes
- typecheck/lint clean (same pre-existing unrelated errors as before, untouched).