### PR TITLE
fix: production footer showing commit: develop

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,13 @@ import { defineConfig } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
+// Cloudflare Pages doesn't set VITE_GIT_COMMIT_SHA itself, but it exposes the
+// deployed commit as CF_PAGES_COMMIT_SHA. Bridge it so Vite's normal VITE_ env
+// handling picks it up, matching what CI already sets explicitly.
+if (!process.env.VITE_GIT_COMMIT_SHA && process.env.CF_PAGES_COMMIT_SHA) {
+  process.env.VITE_GIT_COMMIT_SHA = process.env.CF_PAGES_COMMIT_SHA;
+}
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
@@ -50,9 +57,6 @@ export default defineConfig({
     extensions: ['.mjs', '.js', '.jsx', '.ts', '.tsx', '.json'],
   },
   define: {
-    'process.env.REACT_APP_GIT_COMMIT_SHA': JSON.stringify(
-      process.env.CF_PAGES_COMMIT_SHA || 'development',
-    ),
     'import.meta.env.DISABLE_REACT_SCAN': JSON.stringify(
       process.env.DISABLE_REACT_SCAN === 'true',
     ),


### PR DESCRIPTION
## Summary
- Production footer showed "commit: develop" instead of the real deployed commit hash.
- `GitCommit.tsx` falls back to the literal string `'development'` when `VITE_GIT_COMMIT_SHA` is unset, and truncating that to 7 chars spells "develop".
- CI sets `VITE_GIT_COMMIT_SHA` correctly, but CI no longer deploys (Cloudflare Pages deploy job removed in #901, Vercel fully removed in #906). Production now builds via Cloudflare Pages' native Git integration, which exposes the deployed commit only as `CF_PAGES_COMMIT_SHA`, not `VITE_GIT_COMMIT_SHA`.
- A prior attempt to bridge this in `vite.config.js` wired `CF_PAGES_COMMIT_SHA` to `process.env.REACT_APP_GIT_COMMIT_SHA`, a leftover Create-React-App-style name that nothing in the app reads.
- Fixed by setting `process.env.VITE_GIT_COMMIT_SHA` from `process.env.CF_PAGES_COMMIT_SHA` at the top of `vite.config.js` (before Vite resolves its env vars) when `VITE_GIT_COMMIT_SHA` isn't already set, and removed the dead define entry.