### PR TITLE
Add unit tests for betStore, roundStore, and the stores selector layer

### DIFF
--- a/src/app/stores/__tests__/betStore.test.ts
+++ b/src/app/stores/__tests__/betStore.test.ts
@@ -1,0 +1,416 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { Bet, BetAmount } from '../../../types/bets';
+import { BET_AMOUNT_DEFAULT, BET_AMOUNT_MIN } from '../../constants';
+import { useBetStore } from '../betStore';
+
+// Mock universal-cookie before any store imports
+vi.mock('universal-cookie', () => ({
+  default: vi.fn().mockImplementation(function () {
+    return {
+      get: vi.fn().mockReturnValue(undefined),
+      set: vi.fn(),
+    };
+  }),
+}));
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+globalThis.fetch = mockFetch;
+
+// Allow the betStore's lazy dynamic import of roundStore to resolve
+async function waitForStoreInit(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 50));
+}
+
+function makeBets(pirates: number[][] = []): Bet {
+  const bets: Bet = new Map();
+  for (let i = 0; i < pirates.length; i++) {
+    bets.set(i + 1, pirates[i] ?? [0, 0, 0, 0, 0]);
+  }
+  for (let i = pirates.length; i < 10; i++) {
+    bets.set(i + 1, [0, 0, 0, 0, 0]);
+  }
+  return bets;
+}
+
+function makeAmounts(amounts: number[] = []): BetAmount {
+  const result: BetAmount = new Map();
+  for (let i = 0; i < amounts.length; i++) {
+    result.set(i + 1, amounts[i] ?? BET_AMOUNT_DEFAULT);
+  }
+  for (let i = amounts.length; i < 10; i++) {
+    result.set(i + 1, BET_AMOUNT_DEFAULT);
+  }
+  return result;
+}
+
+describe('betStore', () => {
+  beforeEach(async () => {
+    // Wait for the betStore's dynamic import of roundStore to resolve
+    await waitForStoreInit();
+
+    mockFetch.mockImplementation(() => Promise.resolve({ ok: false, status: 404 }));
+
+    useBetStore.setState({
+      currentBet: 0,
+      allNames: new Map([[0, 'Starting Set']]),
+      allBets: new Map([[0, makeBets()]]),
+      allBetAmounts: new Map([[0, makeAmounts()]]),
+    });
+  });
+
+  describe('setCurrentBet', () => {
+    it('updates currentBet', () => {
+      useBetStore.getState().setCurrentBet(3);
+      expect(useBetStore.getState().currentBet).toBe(3);
+    });
+  });
+
+  describe('addNewSet', () => {
+    it('adds a new index when replace is false', () => {
+      const bets = makeBets([[1, 0, 0, 0, 0]]);
+      const amounts = makeAmounts([1000]);
+
+      useBetStore.getState().addNewSet('New Set', bets, amounts, false);
+
+      const state = useBetStore.getState();
+      expect(state.allBets.size).toBe(2);
+      expect(state.currentBet).toBe(1);
+      expect(state.allNames.get(1)).toBe('New Set');
+      expect(state.allBets.get(1)).toBe(bets);
+      expect(state.allBetAmounts.get(1)).toBe(amounts);
+      // original set untouched
+      expect(state.allBets.has(0)).toBe(true);
+    });
+
+    it('adds a new index when replace is true but the current set has real bets', () => {
+      useBetStore.setState({
+        allBets: new Map([[0, makeBets([[1, 0, 0, 0, 0]])]]),
+        allBetAmounts: new Map([[0, makeAmounts()]]),
+        allNames: new Map([[0, 'Starting Set']]),
+        currentBet: 0,
+      });
+
+      const bets = makeBets([[2, 0, 0, 0, 0]]);
+      const amounts = makeAmounts();
+
+      useBetStore.getState().addNewSet('Replacement', bets, amounts, true);
+
+      const state = useBetStore.getState();
+      expect(state.allBets.size).toBe(2);
+      expect(state.currentBet).toBe(1);
+      expect(state.allNames.get(1)).toBe('Replacement');
+    });
+
+    it('replaces the current index in-place when replace is true and current set is empty', () => {
+      // starting set has no real bets (all zeros)
+      const bets = makeBets([[3, 0, 0, 0, 0]]);
+      const amounts = makeAmounts([2000]);
+
+      useBetStore.getState().addNewSet('Replaced', bets, amounts, true);
+
+      const state = useBetStore.getState();
+      expect(state.allBets.size).toBe(1);
+      expect(state.currentBet).toBe(0);
+      expect(state.allNames.get(0)).toBe('Replaced');
+      expect(state.allBets.get(0)).toBe(bets);
+      expect(state.allBetAmounts.get(0)).toBe(amounts);
+    });
+
+    it('trims the provided name', () => {
+      useBetStore.getState().addNewSet('  spaced name  ', makeBets(), makeAmounts(), false);
+      expect(useBetStore.getState().allNames.get(1)).toBe('spaced name');
+    });
+  });
+
+  describe('updateBetName', () => {
+    it('updates an existing index name, trimmed', () => {
+      useBetStore.getState().updateBetName(0, '  Renamed  ');
+      expect(useBetStore.getState().allNames.get(0)).toBe('Renamed');
+    });
+
+    it('no-ops silently for a nonexistent index', () => {
+      const before = useBetStore.getState().allNames;
+      useBetStore.getState().updateBetName(99, 'Nope');
+      expect(useBetStore.getState().allNames).toBe(before);
+      expect(useBetStore.getState().allNames.has(99)).toBe(false);
+    });
+  });
+
+  describe('deleteBetSet', () => {
+    beforeEach(() => {
+      useBetStore.setState({
+        currentBet: 1,
+        allNames: new Map([
+          [0, 'Set 0'],
+          [1, 'Set 1'],
+          [2, 'Set 2'],
+        ]),
+        allBets: new Map([
+          [0, makeBets()],
+          [1, makeBets()],
+          [2, makeBets()],
+        ]),
+        allBetAmounts: new Map([
+          [0, makeAmounts()],
+          [1, makeAmounts()],
+          [2, makeAmounts()],
+        ]),
+      });
+    });
+
+    it('removes a set when more than 1 exists', () => {
+      useBetStore.getState().deleteBetSet(2);
+      const state = useBetStore.getState();
+      expect(state.allBets.has(2)).toBe(false);
+      expect(state.allBets.size).toBe(2);
+    });
+
+    it('refuses to delete when only 1 set remains', () => {
+      useBetStore.setState({
+        currentBet: 0,
+        allNames: new Map([[0, 'Only Set']]),
+        allBets: new Map([[0, makeBets()]]),
+        allBetAmounts: new Map([[0, makeAmounts()]]),
+      });
+      const before = useBetStore.getState();
+      useBetStore.getState().deleteBetSet(0);
+      const after = useBetStore.getState();
+      expect(after).toBe(before);
+      expect(after.allBets.size).toBe(1);
+    });
+
+    it('refuses for a nonexistent index', () => {
+      const before = useBetStore.getState();
+      useBetStore.getState().deleteBetSet(99);
+      expect(useBetStore.getState()).toBe(before);
+    });
+
+    it('moves currentBet to the previous key when deleting the current index', () => {
+      // currentBet = 1, deleting 1, prevKey should be 0
+      useBetStore.getState().deleteBetSet(1);
+      expect(useBetStore.getState().currentBet).toBe(0);
+    });
+
+    it('moves currentBet to the next key when deleting the current index and no previous key exists', () => {
+      useBetStore.setState({ currentBet: 0 });
+      // deleting 0, no prevKey, nextKey should be 1
+      useBetStore.getState().deleteBetSet(0);
+      expect(useBetStore.getState().currentBet).toBe(1);
+    });
+
+    it('moves currentBet to the first remaining key when neither prev nor next exist for that index', () => {
+      // Only keys 0 and 2 remain scenario: delete middle key 1 while current is 1 covered above.
+      // Here test deleting the last remaining current index with no next/prev by using a fresh 2-set fixture
+      useBetStore.setState({
+        currentBet: 5,
+        allNames: new Map([
+          [5, 'Only current'],
+          [7, 'Other'],
+        ]),
+        allBets: new Map([
+          [5, makeBets()],
+          [7, makeBets()],
+        ]),
+        allBetAmounts: new Map([
+          [5, makeAmounts()],
+          [7, makeAmounts()],
+        ]),
+      });
+      useBetStore.getState().deleteBetSet(5);
+      expect(useBetStore.getState().currentBet).toBe(7);
+    });
+  });
+
+  describe('swapBets', () => {
+    it('swaps bet lines and amounts at the computed indices, leaving others untouched', () => {
+      const bets = makeBets([
+        [1, 0, 0, 0, 0],
+        [2, 0, 0, 0, 0],
+        [3, 0, 0, 0, 0],
+      ]);
+      const amounts = makeAmounts([100, 200, 300]);
+      useBetStore.setState({
+        currentBet: 0,
+        allBets: new Map([[0, bets]]),
+        allBetAmounts: new Map([[0, amounts]]),
+      });
+
+      // UI indices 0 and 1 correspond to betIndex 1 and 2
+      useBetStore.getState().swapBets(0, 1);
+
+      const state = useBetStore.getState();
+      const newBets = state.allBets.get(0)!;
+      const newAmounts = state.allBetAmounts.get(0)!;
+      expect(newBets.get(1)).toEqual([2, 0, 0, 0, 0]);
+      expect(newBets.get(2)).toEqual([1, 0, 0, 0, 0]);
+      expect(newAmounts.get(1)).toBe(200);
+      expect(newAmounts.get(2)).toBe(100);
+      // untouched
+      expect(newBets.get(3)).toEqual([3, 0, 0, 0, 0]);
+      expect(newAmounts.get(3)).toBe(300);
+    });
+
+    it('no-ops if the current set does not exist', () => {
+      useBetStore.setState({
+        currentBet: 99,
+        allBets: new Map([[0, makeBets()]]),
+        allBetAmounts: new Map([[0, makeAmounts()]]),
+      });
+      const before = useBetStore.getState();
+      useBetStore.getState().swapBets(0, 1);
+      expect(useBetStore.getState()).toBe(before);
+    });
+  });
+
+  describe('updatePirate', () => {
+    it('sets a single arena slot in a single bet line', () => {
+      useBetStore.getState().updatePirate(1, 2, 4);
+      const state = useBetStore.getState();
+      expect(state.allBets.get(0)!.get(1)).toEqual([0, 0, 4, 0, 0]);
+    });
+
+    it('no-ops (returns unchanged state) when the value is already the same', () => {
+      useBetStore.getState().updatePirate(1, 2, 4);
+      const before = useBetStore.getState();
+      useBetStore.getState().updatePirate(1, 2, 4);
+      expect(useBetStore.getState()).toBe(before);
+    });
+  });
+
+  describe('swapPiratesForAllBets', () => {
+    beforeEach(() => {
+      useBetStore.setState({
+        currentBet: 0,
+        allBets: new Map([
+          [
+            0,
+            makeBets([
+              [1, 0, 0, 0, 0],
+              [2, 0, 0, 0, 0],
+              [3, 0, 0, 0, 0],
+            ]),
+          ],
+        ]),
+        allBetAmounts: new Map([[0, makeAmounts()]]),
+      });
+    });
+
+    it('swaps a specific pirate index for another across all bet lines in the given arena', () => {
+      useBetStore.getState().swapPiratesForAllBets(0, 1, 2);
+      const state = useBetStore.getState();
+      const bets = state.allBets.get(0)!;
+      expect(bets.get(1)).toEqual([2, 0, 0, 0, 0]);
+      expect(bets.get(2)).toEqual([1, 0, 0, 0, 0]);
+      // bet line 3 (value 3) doesn't contain pirateIndexA/B, untouched
+      expect(bets.get(3)).toEqual([3, 0, 0, 0, 0]);
+    });
+
+    it('no-ops for arenaIndex outside 0-4', () => {
+      const before = useBetStore.getState();
+      useBetStore.getState().swapPiratesForAllBets(5, 1, 2);
+      expect(useBetStore.getState()).toBe(before);
+
+      useBetStore.getState().swapPiratesForAllBets(-1, 1, 2);
+      expect(useBetStore.getState()).toBe(before);
+    });
+
+    it('no-ops when pirateIndexA === pirateIndexB', () => {
+      const before = useBetStore.getState();
+      useBetStore.getState().swapPiratesForAllBets(0, 1, 1);
+      expect(useBetStore.getState()).toBe(before);
+    });
+
+    it('leaves bet lines untouched that do not contain either pirate index in that arena', () => {
+      const before = useBetStore.getState().allBets.get(0)!.get(3);
+      useBetStore.getState().swapPiratesForAllBets(0, 1, 2);
+      const after = useBetStore.getState().allBets.get(0)!.get(3);
+      expect(after).toEqual(before);
+    });
+  });
+
+  describe('updateBetAmount', () => {
+    it('updates one amount', () => {
+      useBetStore.getState().updateBetAmount(1, 5000);
+      expect(useBetStore.getState().allBetAmounts.get(0)!.get(1)).toBe(5000);
+    });
+
+    it('no-ops if the value is unchanged', () => {
+      useBetStore.getState().updateBetAmount(1, 5000);
+      const before = useBetStore.getState();
+      useBetStore.getState().updateBetAmount(1, 5000);
+      expect(useBetStore.getState()).toBe(before);
+    });
+  });
+
+  describe('updateBetAmounts', () => {
+    it('batch updates amounts', () => {
+      useBetStore.getState().updateBetAmounts([
+        { betIndex: 1, amount: 1000 },
+        { betIndex: 2, amount: 2000 },
+      ]);
+      const amounts = useBetStore.getState().allBetAmounts.get(0)!;
+      expect(amounts.get(1)).toBe(1000);
+      expect(amounts.get(2)).toBe(2000);
+    });
+
+    it('coerces amounts below BET_AMOUNT_MIN to BET_AMOUNT_DEFAULT', () => {
+      useBetStore.getState().updateBetAmounts([{ betIndex: 1, amount: BET_AMOUNT_MIN - 1 }]);
+      const amounts = useBetStore.getState().allBetAmounts.get(0)!;
+      expect(amounts.get(1)).toBe(BET_AMOUNT_DEFAULT);
+    });
+
+    it('no-ops entirely if nothing actually changed', () => {
+      const before = useBetStore.getState();
+      useBetStore.getState().updateBetAmounts([{ betIndex: 1, amount: BET_AMOUNT_DEFAULT }]);
+      expect(useBetStore.getState()).toBe(before);
+    });
+  });
+
+  describe('setAllBets / setAllBetAmounts', () => {
+    it('setAllBets directly replaces the allBets map', () => {
+      const newBets = new Map([[0, makeBets([[1, 0, 0, 0, 0]])]]);
+      useBetStore.getState().setAllBets(newBets);
+      expect(useBetStore.getState().allBets).toBe(newBets);
+    });
+
+    it('setAllBetAmounts directly replaces the allBetAmounts map', () => {
+      const newAmounts = new Map([[0, makeAmounts([1234])]]);
+      useBetStore.getState().setAllBetAmounts(newAmounts);
+      expect(useBetStore.getState().allBetAmounts).toBe(newAmounts);
+    });
+  });
+
+  describe('clearAllBets', () => {
+    it('resets only the current set bets/amounts to empty maps, other sets untouched', () => {
+      useBetStore.setState({
+        currentBet: 0,
+        allBets: new Map([
+          [0, makeBets([[1, 0, 0, 0, 0]])],
+          [1, makeBets([[2, 0, 0, 0, 0]])],
+        ]),
+        allBetAmounts: new Map([
+          [0, makeAmounts([1000])],
+          [1, makeAmounts([2000])],
+        ]),
+      });
+
+      useBetStore.getState().clearAllBets();
+
+      const state = useBetStore.getState();
+      const clearedBets = state.allBets.get(0)!;
+      const clearedAmounts = state.allBetAmounts.get(0)!;
+      expect(clearedBets.size).toBe(10);
+      expect(Array.from(clearedBets.values()).every(line => line.every(v => v === 0))).toBe(true);
+      expect(clearedAmounts.size).toBe(10);
+      expect(
+        Array.from(clearedAmounts.values()).every(amount => amount === BET_AMOUNT_DEFAULT),
+      ).toBe(true);
+
+      // other set untouched
+      expect(state.allBets.get(1)!.get(1)).toEqual([2, 0, 0, 0, 0]);
+      expect(state.allBetAmounts.get(1)!.get(1)).toBe(2000);
+    });
+  });
+});

--- a/src/app/stores/__tests__/index.test.ts
+++ b/src/app/stores/__tests__/index.test.ts
@@ -1,0 +1,410 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { RoundData } from '../../../types';
+import type { Bet, BetAmount } from '../../../types/bets';
+import { BET_AMOUNT_DEFAULT } from '../../constants';
+import { useBetStore } from '../betStore';
+import * as Hooks from '../index';
+import { useRoundStore } from '../roundStore';
+
+// Mock universal-cookie before any store imports
+vi.mock('universal-cookie', () => ({
+  default: vi.fn().mockImplementation(function () {
+    return {
+      get: vi.fn().mockReturnValue(undefined),
+      set: vi.fn(),
+    };
+  }),
+}));
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+globalThis.fetch = mockFetch;
+
+// Allow the betStore's lazy dynamic import of roundStore to resolve
+async function waitForStoreInit(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 50));
+}
+
+function makeBets(pirates: number[][] = []): Bet {
+  const bets: Bet = new Map();
+  for (let i = 0; i < pirates.length; i++) {
+    bets.set(i + 1, pirates[i] ?? [0, 0, 0, 0, 0]);
+  }
+  for (let i = pirates.length; i < 10; i++) {
+    bets.set(i + 1, [0, 0, 0, 0, 0]);
+  }
+  return bets;
+}
+
+function makeAmounts(amounts: number[] = []): BetAmount {
+  const result: BetAmount = new Map();
+  for (let i = 0; i < amounts.length; i++) {
+    result.set(i + 1, amounts[i] ?? BET_AMOUNT_DEFAULT);
+  }
+  for (let i = amounts.length; i < 10; i++) {
+    result.set(i + 1, BET_AMOUNT_DEFAULT);
+  }
+  return result;
+}
+
+const roundData: RoundData = {
+  round: 8000,
+  pirates: [
+    [1, 2, 3, 4],
+    [5, 6, 7, 8],
+    [9, 10, 11, 12],
+    [13, 14, 15, 16],
+    [17, 18, 19, 20],
+  ],
+  openingOdds: [
+    [1, 2, 3, 4, 5],
+    [1, 2, 3, 4, 5],
+    [1, 2, 3, 4, 5],
+    [1, 2, 3, 4, 5],
+    [1, 2, 3, 4, 5],
+  ],
+  currentOdds: [
+    [1, 2, 3, 4, 5],
+    [1, 2, 3, 4, 5],
+    [1, 2, 3, 4, 5],
+    [1, 2, 3, 4, 5],
+    [1, 2, 3, 4, 5],
+  ],
+  foods: [
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+  ],
+  winners: [0, 0, 0, 0, 0],
+};
+
+describe('stores/index hook smoke suite', () => {
+  beforeEach(async () => {
+    await waitForStoreInit();
+
+    mockFetch.mockReset();
+    mockFetch.mockImplementation(() => Promise.resolve({ ok: false, status: 404 }));
+
+    useBetStore.setState({
+      currentBet: 0,
+      allNames: new Map([
+        [0, 'Set A'],
+        [1, 'Set B'],
+      ]),
+      allBets: new Map([
+        [0, makeBets([[1, 5, 9, 13, 17]])],
+        [1, makeBets()],
+      ]),
+      allBetAmounts: new Map([
+        [0, makeAmounts([1000])],
+        [1, makeAmounts()],
+      ]),
+    });
+
+    useRoundStore.setState({
+      roundData,
+      currentRound: 8000,
+      currentSelectedRound: 8000,
+      customOdds: [
+        [1, 2, 3, 4, 5],
+        [1, 2, 3, 4, 5],
+        [1, 2, 3, 4, 5],
+        [1, 2, 3, 4, 5],
+        [1, 2, 3, 4, 5],
+      ],
+      customProbs: null,
+      tableMode: 'normal',
+      betSetPosition: 'below',
+      viewMode: true,
+      useWebDomain: false,
+      bigBrain: true,
+      faDetails: true,
+      customOddsMode: true,
+      oddsTimeline: false,
+      useLogitModel: false,
+      maxBet: 5000,
+      isLoading: false,
+      error: null,
+      pollingIntervalId: null,
+      fetchAbortController: null,
+      isInitializing: false,
+    });
+
+    // Populate real calculations from the seeded state above
+    useRoundStore.getState().recalculate();
+  });
+
+  describe('number-returning hooks', () => {
+    it.each<[string, () => number]>([
+      ['useCurrentBet', Hooks.useCurrentBet],
+      ['useBetCount', Hooks.useBetCount],
+      ['useBetSetCount', Hooks.useBetSetCount],
+      ['useCurrentRound', Hooks.useCurrentRound],
+      ['useSelectedRound', Hooks.useSelectedRound],
+      ['useRoundWinnersBinary', Hooks.useRoundWinnersBinary],
+      ['useMaxBet', Hooks.useMaxBet],
+      ['useTotalBetAmounts', Hooks.useTotalBetAmounts],
+      ['useTotalBetExpectedRatios', Hooks.useTotalBetExpectedRatios],
+      ['useTotalBetNetExpected', Hooks.useTotalBetNetExpected],
+      ['useTotalWinningOdds', Hooks.useTotalWinningOdds],
+      ['useTotalWinningPayoff', Hooks.useTotalWinningPayoff],
+      ['useTotalEnabledBets', Hooks.useTotalEnabledBets],
+      ['useWinningBetBinary', Hooks.useWinningBetBinary],
+      ['useWinnersBinary', Hooks.useWinnersBinary],
+    ])('%s returns a number', (_name, hook) => {
+      const { result } = renderHook(() => hook());
+      expect(result.current).toBeDefined();
+      expect(typeof result.current).toBe('number');
+    });
+  });
+
+  describe('parameterized number-returning hooks', () => {
+    it.each<[string, () => number]>([
+      ['useBetAmount(1)', (): number => Hooks.useBetAmount(1)],
+      ['useBetOddsValue(1)', (): number => Hooks.useBetOddsValue(1)],
+      ['useBetPayoffValue(1)', (): number => Hooks.useBetPayoffValue(1)],
+      ['useBetProbabilityValue(1)', (): number => Hooks.useBetProbabilityValue(1)],
+      ['useBetBinaryValue(1)', (): number => Hooks.useBetBinaryValue(1)],
+      ['useBetExpectedRatioValue(1)', (): number => Hooks.useBetExpectedRatioValue(1)],
+      ['useBetNetExpectedValue(1)', (): number => Hooks.useBetNetExpectedValue(1)],
+      ['useBetMaxBetValue(1)', (): number => Hooks.useBetMaxBetValue(1)],
+      ['useUsedProbabilityValue(0,0)', (): number => Hooks.useUsedProbabilityValue(0, 0)],
+      ['useLogitProbabilityValue(0,0)', (): number => Hooks.useLogitProbabilityValue(0, 0)],
+      ['useLegacyProbabilityMin(0,0)', (): number => Hooks.useLegacyProbabilityMin(0, 0)],
+      ['useLegacyProbabilityMax(0,0)', (): number => Hooks.useLegacyProbabilityMax(0, 0)],
+      ['useLegacyProbabilityStd(0,0)', (): number => Hooks.useLegacyProbabilityStd(0, 0)],
+      ['usePirateFA(0,0)', (): number => Hooks.usePirateFA(0, 0)],
+      ['useSpecificBetAmount(1)', (): number => Hooks.useSpecificBetAmount(1)],
+      ['useSpecificBetOdds(1)', (): number => Hooks.useSpecificBetOdds(1)],
+      ['useSpecificBetPayoff(1)', (): number => Hooks.useSpecificBetPayoff(1)],
+      ['useSpecificBetProbability(1)', (): number => Hooks.useSpecificBetProbability(1)],
+      ['useSpecificBetBinary(1)', (): number => Hooks.useSpecificBetBinary(1)],
+      ['useSpecificBetExpectedRatio(1)', (): number => Hooks.useSpecificBetExpectedRatio(1)],
+      ['useSpecificBetNetExpected(1)', (): number => Hooks.useSpecificBetNetExpected(1)],
+      ['useSpecificBetMaxBet(1)', (): number => Hooks.useSpecificBetMaxBet(1)],
+      ['useStableUsedProbability(0,0)', (): number => Hooks.useStableUsedProbability(0, 0)],
+      ['useStableLogitProbability(0,0)', (): number => Hooks.useStableLogitProbability(0, 0)],
+      [
+        'useStableLegacyProbabilityMin(0,0)',
+        (): number => Hooks.useStableLegacyProbabilityMin(0, 0),
+      ],
+      [
+        'useStableLegacyProbabilityMax(0,0)',
+        (): number => Hooks.useStableLegacyProbabilityMax(0, 0),
+      ],
+      [
+        'useStableLegacyProbabilityStd(0,0)',
+        (): number => Hooks.useStableLegacyProbabilityStd(0, 0),
+      ],
+      ['useStablePirateFA(0,0)', (): number => Hooks.useStablePirateFA(0, 0)],
+      ['useOptimizedBetAmount(1)', (): number => Hooks.useOptimizedBetAmount(1)],
+      ['useCurrentBetForURL', (): number => Hooks.useCurrentBetForURL()],
+    ])('%s returns a number', (_name, hook) => {
+      const { result } = renderHook(() => hook());
+      expect(result.current).toBeDefined();
+      expect(typeof result.current).toBe('number');
+    });
+  });
+
+  describe('parameterized number-or-undefined-returning hooks', () => {
+    it.each<[string, () => number | undefined]>([
+      ['usePirateForArena(0,0)', (): number | undefined => Hooks.usePirateForArena(0, 0)],
+      ['useFoodForArena(0,0)', (): number | undefined => Hooks.useFoodForArena(0, 0)],
+      ['useOpeningOddsValue(0,0)', (): number | undefined => Hooks.useOpeningOddsValue(0, 0)],
+      ['useCurrentOddsValue(0,0)', (): number | undefined => Hooks.useCurrentOddsValue(0, 0)],
+      ['useCustomOddsValue(0,0)', (): number | undefined => Hooks.useCustomOddsValue(0, 0)],
+      ['useCustomProbsValue(0,0)', (): number | undefined => Hooks.useCustomProbsValue(0, 0)],
+      ['usePirateId(0,0)', (): number | undefined => Hooks.usePirateId(0, 0)],
+    ])('%s returns a number or undefined', (_name, hook) => {
+      const { result } = renderHook(() => hook());
+      expect(['number', 'undefined']).toContain(typeof result.current);
+    });
+  });
+
+  describe('boolean-returning hooks', () => {
+    it.each<[string, () => boolean]>([
+      ['useIsLoading', Hooks.useIsLoading],
+      ['useHasAnyBets', Hooks.useHasAnyBets],
+      ['useHasAnyBetsAnywhere', Hooks.useHasAnyBetsAnywhere],
+      ['useHasRoundWinners', Hooks.useHasRoundWinners],
+      ['useViewMode', Hooks.useViewMode],
+      ['useUseWebDomain', Hooks.useUseWebDomain],
+      ['useBigBrain', Hooks.useBigBrain],
+      ['useFaDetails', Hooks.useFaDetails],
+      ['useCustomOddsMode', Hooks.useCustomOddsMode],
+      ['useOddsTimeline', Hooks.useOddsTimeline],
+      ['useLogitModelSetting', Hooks.useLogitModelSetting],
+      ['useIsCalculated', Hooks.useIsCalculated],
+      ['useHasRoundData', Hooks.useHasRoundData],
+      ['useCalculationsStatus', Hooks.useCalculationsStatus],
+    ])('%s returns a boolean', (_name, hook) => {
+      const { result } = renderHook(() => hook());
+      expect(typeof result.current).toBe('boolean');
+    });
+
+    it.each<[string, () => boolean]>([
+      ['useIsPirateSelected(1,0,1)', (): boolean => Hooks.useIsPirateSelected(1, 0, 1)],
+    ])('%s returns a boolean', (_name, hook) => {
+      const { result } = renderHook(() => hook());
+      expect(typeof result.current).toBe('boolean');
+    });
+  });
+
+  describe('string / string-or-undefined-returning hooks', () => {
+    it.each<[string, () => string]>([
+      ['useCurrentBetName', Hooks.useCurrentBetName],
+      ['useTableMode', Hooks.useTableMode],
+      ['useBetSetPosition', Hooks.useBetSetPosition],
+    ])('%s returns a string', (_name, hook) => {
+      const { result } = renderHook(() => hook());
+      expect(typeof result.current).toBe('string');
+    });
+
+    it.each<[string, () => string | undefined]>([
+      ['useTimestamp', Hooks.useTimestamp],
+      ['useLastChange', Hooks.useLastChange],
+      ['useTimestampValue', Hooks.useTimestampValue],
+    ])('%s returns a string or undefined', (_name, hook) => {
+      const { result } = renderHook(() => hook());
+      expect(['string', 'undefined']).toContain(typeof result.current);
+    });
+  });
+
+  describe('array-returning hooks (no args)', () => {
+    it.each<[string, () => unknown]>([
+      ['usePirates', Hooks.usePirates],
+      ['useFoods', Hooks.useFoods],
+      ['useOpeningOdds', Hooks.useOpeningOdds],
+      ['useCurrentOdds', Hooks.useCurrentOdds],
+      ['useArenaRatios', Hooks.useArenaRatios],
+      ['useUsedProbabilities', Hooks.useUsedProbabilities],
+      ['useRoundPirates', Hooks.useRoundPirates],
+      ['useRoundOpeningOdds', Hooks.useRoundOpeningOdds],
+      ['useRoundCurrentOdds', Hooks.useRoundCurrentOdds],
+    ])('%s returns an array', (_name, hook) => {
+      const { result } = renderHook(() => hook());
+      expect(Array.isArray(result.current)).toBe(true);
+    });
+
+    it.each<[string, () => unknown]>([
+      ['useChanges', Hooks.useChanges],
+      ['useWinners', Hooks.useWinners],
+      ['useRoundWinners', Hooks.useRoundWinners],
+      ['useCustomOdds', Hooks.useCustomOdds],
+      ['useCustomProbs', Hooks.useCustomProbs],
+    ])('%s returns an array, null, or undefined', (_name, hook) => {
+      const { result } = renderHook(() => hook());
+      const isArrayNullOrUndefined =
+        result.current === undefined || result.current === null || Array.isArray(result.current);
+      expect(isArrayNullOrUndefined).toBe(true);
+    });
+  });
+
+  describe('parameterized array-or-undefined-returning hooks', () => {
+    it.each<[string, () => unknown]>([
+      ['useBetLine(1)', (): unknown => Hooks.useBetLine(1)],
+      ['useBetLineSpecific(1)', (): unknown => Hooks.useBetLineSpecific(1)],
+      ['usePiratesForArena(0)', (): unknown => Hooks.usePiratesForArena(0)],
+      ['useFoodsForArena(0)', (): unknown => Hooks.useFoodsForArena(0)],
+    ])('%s returns an array or undefined', (_name, hook) => {
+      const { result } = renderHook(() => hook());
+      expect(result.current === undefined || Array.isArray(result.current)).toBe(true);
+    });
+  });
+
+  describe('Map-returning hooks (no args)', () => {
+    it.each<[string, () => unknown]>([
+      ['useAllBets', Hooks.useAllBets],
+      ['useAllBetAmounts', Hooks.useAllBetAmounts],
+      ['useAllBetSetNames', Hooks.useAllBetSetNames],
+      ['useCurrentBets', Hooks.useCurrentBets],
+      ['useCurrentBetAmounts', Hooks.useCurrentBetAmounts],
+      ['useBetOdds', Hooks.useBetOdds],
+      ['useBetPayoffs', Hooks.useBetPayoffs],
+      ['useBetProbabilities', Hooks.useBetProbabilities],
+      ['useBetBinaries', Hooks.useBetBinaries],
+      ['useBetExpectedRatios', Hooks.useBetExpectedRatios],
+      ['useBetNetExpected', Hooks.useBetNetExpected],
+      ['useBetMaxBets', Hooks.useBetMaxBets],
+      ['usePirateFAs', Hooks.usePirateFAs],
+      ['useAllBetsForURLData', Hooks.useAllBetsForURLData],
+      ['useAllBetAmountsForURLData', Hooks.useAllBetAmountsForURLData],
+    ])('%s returns a Map', (_name, hook) => {
+      const { result } = renderHook(() => hook());
+      expect(result.current instanceof Map).toBe(true);
+    });
+  });
+
+  describe('parameterized Map-returning hooks', () => {
+    it.each<[string, () => unknown]>([
+      ['useOptimizedBetsForIndex(0)', (): unknown => Hooks.useOptimizedBetsForIndex(0)],
+      ['useOptimizedBetAmountsForIndex(0)', (): unknown => Hooks.useOptimizedBetAmountsForIndex(0)],
+    ])('%s returns a Map', (_name, hook) => {
+      const { result } = renderHook(() => hook());
+      expect(result.current instanceof Map).toBe(true);
+    });
+  });
+
+  describe('object-returning hooks (no args)', () => {
+    it.each<[string, () => unknown]>([
+      ['useRoundData', Hooks.useRoundData],
+      ['useCalculations', Hooks.useCalculations],
+      ['useLegacyProbabilities', Hooks.useLegacyProbabilities],
+      ['useLogitProbabilities', Hooks.useLogitProbabilities],
+      ['usePayoutTables', Hooks.usePayoutTables],
+    ])('%s returns a defined object', (_name, hook) => {
+      const { result } = renderHook(() => hook());
+      expect(result.current).toBeDefined();
+      expect(typeof result.current).toBe('object');
+      expect(result.current).not.toBeNull();
+    });
+  });
+
+  describe('action/function-returning hooks', () => {
+    it.each<[string, () => unknown]>([
+      ['useSetCurrentBet', Hooks.useSetCurrentBet],
+      ['useAddNewSet', Hooks.useAddNewSet],
+      ['useDeleteBetSet', Hooks.useDeleteBetSet],
+      ['useSwapBets', Hooks.useSwapBets],
+      ['useUpdatePirate', Hooks.useUpdatePirate],
+      ['useSwapPiratesForAllBets', Hooks.useSwapPiratesForAllBets],
+      ['useUpdateBetAmount', Hooks.useUpdateBetAmount],
+      ['useUpdateBetAmounts', Hooks.useUpdateBetAmounts],
+      ['useSetAllBets', Hooks.useSetAllBets],
+      ['useSetAllBetAmounts', Hooks.useSetAllBetAmounts],
+      ['useClearAllBets', Hooks.useClearAllBets],
+      ['useUpdateSelectedRound', Hooks.useUpdateSelectedRound],
+      ['useSetTableMode', Hooks.useSetTableMode],
+      ['useSetBetSetPosition', Hooks.useSetBetSetPosition],
+      ['useSetViewMode', Hooks.useSetViewMode],
+      ['useSetUseWebDomain', Hooks.useSetUseWebDomain],
+      ['useToggleBigBrain', Hooks.useToggleBigBrain],
+      ['useToggleFaDetails', Hooks.useToggleFaDetails],
+      ['useToggleOddsTimeline', Hooks.useToggleOddsTimeline],
+      ['useToggleCustomOddsMode', Hooks.useToggleCustomOddsMode],
+      ['useToggleUseLogitModel', Hooks.useToggleUseLogitModel],
+      ['useSetMaxBet', Hooks.useSetMaxBet],
+      ['useSetCustomOdds', Hooks.useSetCustomOdds],
+      ['useSetCustomProbs', Hooks.useSetCustomProbs],
+      ['useInitializeRoundData', Hooks.useInitializeRoundData],
+      ['useUpdateSinglePirate', Hooks.useUpdateSinglePirate],
+      ['useUpdateSingleBetAmount', Hooks.useUpdateSingleBetAmount],
+      ['useBatchUpdateBetAmounts', Hooks.useBatchUpdateBetAmounts],
+    ])('%s returns a function', (_name, hook) => {
+      const { result } = renderHook(() => hook());
+      expect(typeof result.current).toBe('function');
+    });
+  });
+
+  describe('re-exported stores', () => {
+    it('exposes useBetStore and useRoundStore', () => {
+      expect(typeof Hooks.useBetStore).toBe('function');
+      expect(typeof Hooks.useRoundStore).toBe('function');
+      expect(typeof Hooks.setToastFunction).toBe('function');
+    });
+  });
+});

--- a/src/app/stores/__tests__/roundStore.test.ts
+++ b/src/app/stores/__tests__/roundStore.test.ts
@@ -1,0 +1,452 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import type { RoundCalculationResult, RoundData } from '../../../types';
+import type { Bet, BetAmount } from '../../../types/bets';
+import { BET_AMOUNT_DEFAULT, defaultRoundData } from '../../constants';
+import { useBetStore } from '../betStore';
+import { useRoundStore } from '../roundStore';
+
+// Mock universal-cookie before any store imports
+vi.mock('universal-cookie', () => ({
+  default: vi.fn().mockImplementation(function () {
+    return {
+      get: vi.fn().mockReturnValue(undefined),
+      set: vi.fn(),
+    };
+  }),
+}));
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+globalThis.fetch = mockFetch;
+
+// Allow the betStore's lazy dynamic import of roundStore (and vice versa) to resolve
+async function waitForStoreInit(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 50));
+}
+
+function makeRoundData(overrides: Partial<RoundData> = {}): RoundData {
+  return {
+    round: 8000,
+    pirates: [
+      [1, 2, 3, 4],
+      [5, 6, 7, 8],
+      [9, 10, 11, 12],
+      [13, 14, 15, 16],
+      [17, 18, 19, 20],
+    ],
+    openingOdds: [
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+    ],
+    currentOdds: [
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+      [1, 2, 3, 4, 5],
+    ],
+    foods: [
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    ],
+    winners: [0, 0, 0, 0, 0],
+    ...overrides,
+  };
+}
+
+const blankCalculations: RoundCalculationResult = {
+  calculated: false,
+  legacyProbabilities: { min: [], std: [], max: [], used: [] },
+  logitProbabilities: { prob: [], used: [] },
+  usedProbabilities: [],
+  pirateFAs: new Map(),
+  arenaRatios: [],
+  betOdds: new Map(),
+  betPayoffs: new Map(),
+  betProbabilities: new Map(),
+  betExpectedRatios: new Map(),
+  betNetExpected: new Map(),
+  betMaxBets: new Map(),
+  betBinaries: new Map(),
+  odds: [],
+  payoutTables: { odds: [], winnings: [] },
+  winningBetBinary: 0,
+  totalBetAmounts: 0,
+  totalBetExpectedRatios: 0,
+  totalBetNetExpected: 0,
+  totalWinningPayoff: 0,
+  totalWinningOdds: 0,
+  totalEnabledBets: 0,
+};
+
+function makeBets(pirates: number[][] = []): Bet {
+  const bets: Bet = new Map();
+  for (let i = 0; i < pirates.length; i++) {
+    bets.set(i + 1, pirates[i] ?? [0, 0, 0, 0, 0]);
+  }
+  for (let i = pirates.length; i < 10; i++) {
+    bets.set(i + 1, [0, 0, 0, 0, 0]);
+  }
+  return bets;
+}
+
+function makeAmounts(amounts: number[] = []): BetAmount {
+  const result: BetAmount = new Map();
+  for (let i = 0; i < amounts.length; i++) {
+    result.set(i + 1, amounts[i] ?? BET_AMOUNT_DEFAULT);
+  }
+  for (let i = amounts.length; i < 10; i++) {
+    result.set(i + 1, BET_AMOUNT_DEFAULT);
+  }
+  return result;
+}
+
+function seedRealBets(): void {
+  useBetStore.setState({
+    currentBet: 0,
+    allNames: new Map([[0, 'Test Set']]),
+    allBets: new Map([[0, makeBets([[1, 5, 9, 13, 17]])]]),
+    allBetAmounts: new Map([[0, makeAmounts([1000])]]),
+  });
+}
+
+describe('roundStore', () => {
+  beforeEach(async () => {
+    await waitForStoreInit();
+
+    mockFetch.mockReset();
+    mockFetch.mockImplementation(() => Promise.resolve({ ok: false, status: 404 }));
+
+    useRoundStore.setState({
+      roundData: defaultRoundData,
+      currentRound: 8000,
+      currentSelectedRound: 8000,
+      customOdds: null,
+      customProbs: null,
+      tableMode: 'normal',
+      betSetPosition: 'below',
+      viewMode: false,
+      useWebDomain: false,
+      bigBrain: true,
+      faDetails: false,
+      customOddsMode: false,
+      oddsTimeline: false,
+      useLogitModel: false,
+      maxBet: BET_AMOUNT_DEFAULT,
+      calculations: blankCalculations,
+      isLoading: false,
+      error: null,
+      pollingIntervalId: null,
+      fetchAbortController: null,
+      isInitializing: false,
+    });
+
+    seedRealBets();
+  });
+
+  afterEach(() => {
+    useRoundStore.getState().stopPolling();
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  describe('updateSelectedRound', () => {
+    it('no-ops if round equals currentSelectedRound', () => {
+      const before = useRoundStore.getState();
+      useRoundStore.getState().updateSelectedRound(8000);
+      expect(useRoundStore.getState()).toBe(before);
+    });
+
+    it('updates currentSelectedRound and resets customOdds/customProbs/error, recomputes maxBet', () => {
+      useRoundStore.setState({
+        customOdds: [[1, 2]],
+        customProbs: [[0.5, 0.5]],
+        error: 'previous error',
+        maxBet: 99999,
+      });
+
+      useRoundStore.getState().updateSelectedRound(9000);
+
+      const state = useRoundStore.getState();
+      expect(state.currentSelectedRound).toBe(9000);
+      expect(state.customOdds).toBeNull();
+      expect(state.customProbs).toBeNull();
+      expect(state.error).toBeNull();
+      // cookies are mocked to always return undefined, so getMaxBet falls back to BET_AMOUNT_DEFAULT
+      expect(state.maxBet).toBe(BET_AMOUNT_DEFAULT);
+    });
+
+    it('aborts any in-flight fetchAbortController', () => {
+      const controller = new AbortController();
+      const abortSpy = vi.spyOn(controller, 'abort');
+      useRoundStore.setState({ fetchAbortController: controller });
+
+      useRoundStore.getState().updateSelectedRound(9500);
+
+      expect(abortSpy).toHaveBeenCalledWith('round_changed');
+    });
+  });
+
+  describe('setCustomOdds', () => {
+    it('sets the value and triggers recalculate', () => {
+      useRoundStore.setState({ roundData: makeRoundData(), calculations: blankCalculations });
+
+      useRoundStore.getState().setCustomOdds([[1, 2, 3, 4, 5]]);
+
+      const state = useRoundStore.getState();
+      expect(state.customOdds).toEqual([[1, 2, 3, 4, 5]]);
+      expect(state.calculations).not.toBe(blankCalculations);
+      expect(state.calculations.calculated).toBe(true);
+    });
+  });
+
+  describe('setCustomProbs', () => {
+    it('sets the value and triggers recalculate', () => {
+      useRoundStore.setState({ roundData: makeRoundData(), calculations: blankCalculations });
+
+      useRoundStore.getState().setCustomProbs([[0.1, 0.2, 0.3, 0.4]]);
+
+      const state = useRoundStore.getState();
+      expect(state.customProbs).toEqual([[0.1, 0.2, 0.3, 0.4]]);
+      expect(state.calculations).not.toBe(blankCalculations);
+      expect(state.calculations.calculated).toBe(true);
+    });
+  });
+
+  describe('trivial direct setters', () => {
+    it('setTableMode', () => {
+      useRoundStore.getState().setTableMode('dropdown');
+      expect(useRoundStore.getState().tableMode).toBe('dropdown');
+    });
+
+    it('setBetSetPosition', () => {
+      useRoundStore.getState().setBetSetPosition('right');
+      expect(useRoundStore.getState().betSetPosition).toBe('right');
+    });
+
+    it('setViewMode', () => {
+      useRoundStore.getState().setViewMode(true);
+      expect(useRoundStore.getState().viewMode).toBe(true);
+    });
+
+    it('setUseWebDomain', () => {
+      useRoundStore.getState().setUseWebDomain(true);
+      expect(useRoundStore.getState().useWebDomain).toBe(true);
+    });
+
+    it('setMaxBet', () => {
+      useRoundStore.getState().setMaxBet(12345);
+      expect(useRoundStore.getState().maxBet).toBe(12345);
+    });
+  });
+
+  describe('simple boolean flips (no recalculate)', () => {
+    it('toggleBigBrain flips bigBrain', () => {
+      const before = useRoundStore.getState().bigBrain;
+      useRoundStore.getState().toggleBigBrain();
+      expect(useRoundStore.getState().bigBrain).toBe(!before);
+    });
+
+    it('toggleFaDetails flips faDetails', () => {
+      const before = useRoundStore.getState().faDetails;
+      useRoundStore.getState().toggleFaDetails();
+      expect(useRoundStore.getState().faDetails).toBe(!before);
+    });
+
+    it('toggleOddsTimeline flips oddsTimeline', () => {
+      const before = useRoundStore.getState().oddsTimeline;
+      useRoundStore.getState().toggleOddsTimeline();
+      expect(useRoundStore.getState().oddsTimeline).toBe(!before);
+    });
+  });
+
+  describe('boolean flips that also trigger recalculate', () => {
+    it('toggleCustomOddsMode flips the flag and recomputes calculations', () => {
+      useRoundStore.setState({ roundData: makeRoundData(), calculations: blankCalculations });
+      const before = useRoundStore.getState().customOddsMode;
+
+      useRoundStore.getState().toggleCustomOddsMode();
+
+      const state = useRoundStore.getState();
+      expect(state.customOddsMode).toBe(!before);
+      expect(state.calculations).not.toBe(blankCalculations);
+      expect(state.calculations.calculated).toBe(true);
+    });
+
+    it('toggleUseLogitModel flips the flag and recomputes calculations', () => {
+      useRoundStore.setState({ roundData: makeRoundData(), calculations: blankCalculations });
+      const before = useRoundStore.getState().useLogitModel;
+
+      useRoundStore.getState().toggleUseLogitModel();
+
+      const state = useRoundStore.getState();
+      expect(state.useLogitModel).toBe(!before);
+      expect(state.calculations).not.toBe(blankCalculations);
+      expect(state.calculations.calculated).toBe(true);
+    });
+  });
+
+  describe('updateRoundData', () => {
+    it('ignores data for a round that does not match currentSelectedRound', () => {
+      const original = makeRoundData({ round: 8000 });
+      useRoundStore.setState({ roundData: original, currentSelectedRound: 8000 });
+
+      useRoundStore.getState().updateRoundData(makeRoundData({ round: 9999 }));
+
+      expect(useRoundStore.getState().roundData).toBe(original);
+    });
+
+    it('updates roundData and clears error when the round matches', () => {
+      useRoundStore.setState({
+        roundData: makeRoundData({ round: 8000 }),
+        currentSelectedRound: 8000,
+        error: 'boom',
+      });
+
+      const updated = makeRoundData({ round: 8000, timestamp: '2026-01-01T00:00:00Z' });
+      useRoundStore.getState().updateRoundData(updated);
+
+      const state = useRoundStore.getState();
+      expect(state.roundData).toBe(updated);
+      expect(state.error).toBeNull();
+    });
+
+    it('does not trigger recalculate when odds, winners, and round are all unchanged', () => {
+      const original = makeRoundData({ round: 8000 });
+      useRoundStore.setState({ roundData: original, currentSelectedRound: 8000 });
+
+      const recalcSpy = vi.spyOn(useRoundStore.getState(), 'recalculate');
+
+      // Same values, different object/array references
+      useRoundStore.getState().updateRoundData(makeRoundData({ round: 8000 }));
+
+      expect(recalcSpy).not.toHaveBeenCalled();
+    });
+
+    it('triggers recalculate when odds changed', () => {
+      useRoundStore.setState({
+        roundData: makeRoundData({ round: 8000 }),
+        currentSelectedRound: 8000,
+      });
+      const recalcSpy = vi.spyOn(useRoundStore.getState(), 'recalculate');
+
+      useRoundStore.getState().updateRoundData(
+        makeRoundData({
+          round: 8000,
+          currentOdds: [
+            [1, 9, 9, 9, 9],
+            [1, 2, 3, 4, 5],
+            [1, 2, 3, 4, 5],
+            [1, 2, 3, 4, 5],
+            [1, 2, 3, 4, 5],
+          ],
+        }),
+      );
+
+      expect(recalcSpy).toHaveBeenCalled();
+    });
+
+    it('triggers recalculate when winners changed', () => {
+      useRoundStore.setState({
+        roundData: makeRoundData({ round: 8000 }),
+        currentSelectedRound: 8000,
+      });
+      const recalcSpy = vi.spyOn(useRoundStore.getState(), 'recalculate');
+
+      useRoundStore
+        .getState()
+        .updateRoundData(makeRoundData({ round: 8000, winners: [1, 0, 0, 0, 0] }));
+
+      expect(recalcSpy).toHaveBeenCalled();
+    });
+
+    it('triggers recalculate when the round number itself changed', () => {
+      useRoundStore.setState({
+        roundData: makeRoundData({ round: 8000 }),
+        currentSelectedRound: 8001,
+      });
+      const recalcSpy = vi.spyOn(useRoundStore.getState(), 'recalculate');
+
+      useRoundStore.getState().updateRoundData(makeRoundData({ round: 8001 }));
+
+      expect(recalcSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('recalculate', () => {
+    it('early-returns emptyCalculations when roundData is the defaultRoundData sentinel', () => {
+      useRoundStore.setState({ roundData: defaultRoundData, calculations: blankCalculations });
+
+      useRoundStore.getState().recalculate();
+
+      expect(useRoundStore.getState().calculations.calculated).toBe(false);
+    });
+
+    it('early-returns emptyCalculations when roundData.pirates is empty', () => {
+      useRoundStore.setState({
+        roundData: makeRoundData({ pirates: [] }),
+        calculations: blankCalculations,
+      });
+
+      useRoundStore.getState().recalculate();
+
+      expect(useRoundStore.getState().calculations.calculated).toBe(false);
+    });
+
+    it('produces real non-empty calculations for valid round data with real bets seeded', () => {
+      useRoundStore.setState({
+        roundData: makeRoundData(),
+        currentSelectedRound: 8000,
+        calculations: blankCalculations,
+      });
+
+      useRoundStore.getState().recalculate();
+
+      const { calculations } = useRoundStore.getState();
+      expect(calculations.calculated).toBe(true);
+      expect(calculations.betOdds.size).toBeGreaterThan(0);
+      expect(calculations.arenaRatios.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('fetchRoundData', () => {
+    it('sets error to a non-null string and isLoading to false on a non-ok response', async () => {
+      useRoundStore.setState({ currentSelectedRound: 8000, isInitializing: false });
+      mockFetch.mockImplementation(() => Promise.resolve({ ok: false, status: 404 }));
+
+      await useRoundStore.getState().fetchRoundData(8000);
+
+      const state = useRoundStore.getState();
+      expect(state.error).toEqual(expect.any(String));
+      expect(state.error).not.toBeNull();
+      expect(state.isLoading).toBe(false);
+    });
+
+    it('updates roundData and recalculates on a successful response', async () => {
+      useRoundStore.setState({ currentSelectedRound: 8000, isInitializing: false });
+      const freshRoundData = makeRoundData({ round: 8000, timestamp: '2026-05-01T00:00:00Z' });
+      mockFetch.mockImplementation(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(freshRoundData),
+        }),
+      );
+
+      const shouldStop = await useRoundStore.getState().fetchRoundData(8000);
+
+      const state = useRoundStore.getState();
+      expect(shouldStop).toBe(false);
+      expect(state.error).toBeNull();
+      expect(state.isLoading).toBe(false);
+      expect(state.roundData.timestamp).toBe('2026-05-01T00:00:00Z');
+      expect(state.calculations.calculated).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Phase 3 of the test-coverage expansion effort (Phase 0: #899, Phase 1: #902, Phase 2.1/2.2/2.3: #905/#907/#909).
- Adds 197 tests across 3 new files covering src/app/stores/betStore.ts, roundStore.ts, and a table-driven smoke suite over the ~141 selector hooks re-exported from stores/index.ts.
- Intentionally scoped to synchronous store actions and one success/one failure fetch path rather than exhaustive polling/race-condition coverage of startPolling/visibilitychange/initialize(), which are already exercised end-to-end by the existing hashchange.test.ts.
- This branch is independent of the other open phase PRs (built from master with its own fixtures) so it can be reviewed/merged in any order.

## Notes
- typecheck/lint clean (same pre-existing unrelated errors as before, untouched).