### PR TITLE
Add unit tests for DateFormatter, Td, and six pure ui/ components

### DIFF
--- a/src/app/components/format/__tests__/DateFormatter.test.tsx
+++ b/src/app/components/format/__tests__/DateFormatter.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { render, screen } from '../../../../test/utils';
+import { useFormattedDate } from '../../../hooks/useFormattedDate';
+import DateFormatter from '../DateFormatter';
+
+vi.mock('../../../hooks/useFormattedDate', () => ({
+  useFormattedDate: vi.fn(),
+}));
+
+const mockUseFormattedDate = vi.mocked(useFormattedDate);
+
+describe('DateFormatter', () => {
+  it('renders the formatted date text content inside a span', () => {
+    mockUseFormattedDate.mockReturnValue({ formattedDate: 'July 9, 2026', title: '' });
+
+    render(<DateFormatter date="2026-07-09" />);
+
+    const span = screen.getByText('July 9, 2026');
+    expect(span).toBeInTheDocument();
+    expect(span.tagName).toBe('SPAN');
+  });
+
+  it('passes through arbitrary HTML span props', () => {
+    mockUseFormattedDate.mockReturnValue({ formattedDate: 'July 9, 2026', title: '' });
+
+    render(<DateFormatter date="2026-07-09" className="my-class" data-testid="date-formatter" />);
+
+    const span = screen.getByTestId('date-formatter');
+    expect(span).toBeInTheDocument();
+    expect(span).toHaveClass('my-class');
+    expect(span).toHaveTextContent('July 9, 2026');
+  });
+
+  it('sets the title attribute when withTitle/titleFormat produce one', () => {
+    mockUseFormattedDate.mockReturnValue({
+      formattedDate: 'July 9, 2026',
+      title: 'Thursday, July 9, 2026',
+    });
+
+    render(<DateFormatter date="2026-07-09" withTitle titleFormat="dddd, MMMM D, YYYY" />);
+
+    const span = screen.getByText('July 9, 2026');
+    expect(span).toHaveAttribute('title', 'Thursday, July 9, 2026');
+  });
+
+  it('omits a meaningful title attribute when not provided', () => {
+    mockUseFormattedDate.mockReturnValue({ formattedDate: 'July 9, 2026', title: '' });
+
+    render(<DateFormatter date="2026-07-09" />);
+
+    const span = screen.getByText('July 9, 2026');
+    expect(span).toHaveAttribute('title', '');
+  });
+
+  it('calls useFormattedDate with the provided options', () => {
+    mockUseFormattedDate.mockReturnValue({ formattedDate: 'July 9, 2026', title: '' });
+
+    render(<DateFormatter date="2026-07-09" format="MMMM D, YYYY" fromNow tz="UTC" />);
+
+    expect(mockUseFormattedDate).toHaveBeenCalledWith('2026-07-09', {
+      format: 'MMMM D, YYYY',
+      fromNow: true,
+      tz: 'UTC',
+    });
+  });
+});

--- a/src/app/components/tables/__tests__/Td.test.tsx
+++ b/src/app/components/tables/__tests__/Td.test.tsx
@@ -1,0 +1,40 @@
+import { Table } from '@chakra-ui/react';
+import { describe, it, expect } from 'vitest';
+
+import { render, screen } from '../../../../test/utils';
+import Td from '../Td';
+
+describe('Td', () => {
+  it('renders children inside a table cell', () => {
+    render(
+      <Table.Root>
+        <Table.Body>
+          <Table.Row>
+            <Td>Cell Content</Td>
+          </Table.Row>
+        </Table.Body>
+      </Table.Root>,
+    );
+
+    const cell = screen.getByText('Cell Content');
+    expect(cell).toBeInTheDocument();
+    expect(cell.tagName).toBe('TD');
+  });
+
+  it('forwards additional props to the underlying Table.Cell', () => {
+    render(
+      <Table.Root>
+        <Table.Body>
+          <Table.Row>
+            <Td data-testid="custom-td" colSpan={2}>
+              Data
+            </Td>
+          </Table.Row>
+        </Table.Body>
+      </Table.Root>,
+    );
+
+    const cell = screen.getByTestId('custom-td');
+    expect(cell).toHaveAttribute('colspan', '2');
+  });
+});

--- a/src/app/components/ui/__tests__/ErrorBoundary.test.tsx
+++ b/src/app/components/ui/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,101 @@
+import { fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import { render, screen } from '../../../../test/utils';
+import ErrorBoundary from '../ErrorBoundary';
+
+const Bomb = (): React.ReactElement => {
+  throw new Error('boom');
+};
+
+describe('ErrorBoundary', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders children normally when no error occurs', () => {
+    render(
+      <ErrorBoundary>
+        <div data-testid="child">All good</div>
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+    expect(screen.getByText('All good')).toBeInTheDocument();
+  });
+
+  it('catches an error thrown during render and shows the fallback UI', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('Something went wrong!')).toBeInTheDocument();
+    expect(
+      screen.getByText('The application encountered an unexpected error and needs to be reloaded.'),
+    ).toBeInTheDocument();
+  });
+
+  it('resets hasError back to false when "Try Again" is clicked', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const { rerender } = render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('Something went wrong!')).toBeInTheDocument();
+
+    // Swap in a non-throwing child before resetting. The class component's
+    // state still has hasError=true at this point, so the fallback UI
+    // remains on screen (render() ignores the new children until reset).
+    rerender(
+      <ErrorBoundary>
+        <div data-testid="recovered">Recovered</div>
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('Something went wrong!')).toBeInTheDocument();
+
+    const tryAgainButton = screen.getByRole('button', { name: 'Try Again' });
+    fireEvent.click(tryAgainButton);
+
+    // Resetting hasError now lets the (already-swapped) non-throwing
+    // children render instead of the fallback UI.
+    expect(screen.queryByText('Something went wrong!')).not.toBeInTheDocument();
+    expect(screen.getByTestId('recovered')).toBeInTheDocument();
+  });
+
+  it('calls window.location.reload when "Reload Page" is clicked', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const reloadMock = vi.fn();
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, reload: reloadMock },
+    });
+
+    try {
+      render(
+        <ErrorBoundary>
+          <Bomb />
+        </ErrorBoundary>,
+      );
+
+      const reloadButton = screen.getByRole('button', { name: 'Reload Page' });
+      fireEvent.click(reloadButton);
+
+      expect(reloadMock).toHaveBeenCalledTimes(1);
+    } finally {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: originalLocation,
+      });
+    }
+  });
+});

--- a/src/app/components/ui/__tests__/GitCommit.test.tsx
+++ b/src/app/components/ui/__tests__/GitCommit.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import { render, screen } from '../../../../test/utils';
+import { GitCommit } from '../GitCommit';
+
+describe('GitCommit', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('renders the short hash without a link when the commit is "development"', () => {
+    vi.stubEnv('VITE_GIT_COMMIT_SHA', 'development');
+
+    render(<GitCommit />);
+
+    expect(screen.getByText('develop')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('renders a link to the commit on GitHub with the short hash when a real commit sha is set', () => {
+    vi.stubEnv('VITE_GIT_COMMIT_SHA', 'abcdef1234567890');
+
+    render(<GitCommit />);
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute(
+      'href',
+      'https://github.com/rneopets/neofoodclub/commit/abcdef1234567890',
+    );
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(link).toHaveTextContent('abcdef1');
+  });
+});

--- a/src/app/components/ui/__tests__/GlowCard.test.tsx
+++ b/src/app/components/ui/__tests__/GlowCard.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+
+import { render, screen } from '../../../../test/utils';
+import GlowCard from '../GlowCard';
+
+describe('GlowCard', () => {
+  it('renders children', () => {
+    render(
+      <GlowCard>
+        <div data-testid="glow-child">Inside the card</div>
+      </GlowCard>,
+    );
+
+    expect(screen.getByTestId('glow-child')).toBeInTheDocument();
+    expect(screen.getByText('Inside the card')).toBeInTheDocument();
+  });
+
+  it('forwards additional Box props such as data-testid', () => {
+    render(
+      <GlowCard data-testid="glow-card">
+        <span>Content</span>
+      </GlowCard>,
+    );
+
+    expect(screen.getByTestId('glow-card')).toBeInTheDocument();
+  });
+
+  it('renders without crashing when animate is true', () => {
+    render(
+      <GlowCard animate>
+        <span>Animated Content</span>
+      </GlowCard>,
+    );
+
+    expect(screen.getByText('Animated Content')).toBeInTheDocument();
+  });
+
+  it('renders without crashing when animate is false/undefined', () => {
+    render(
+      <GlowCard>
+        <span>Static Content</span>
+      </GlowCard>,
+    );
+
+    expect(screen.getByText('Static Content')).toBeInTheDocument();
+  });
+});

--- a/src/app/components/ui/__tests__/SettingsBox.test.tsx
+++ b/src/app/components/ui/__tests__/SettingsBox.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+
+import { render, screen } from '../../../../test/utils';
+import SettingsBox from '../SettingsBox';
+
+describe('SettingsBox', () => {
+  it('renders children', () => {
+    render(
+      <SettingsBox>
+        <div data-testid="settings-child">Settings Content</div>
+      </SettingsBox>,
+    );
+
+    expect(screen.getByTestId('settings-child')).toBeInTheDocument();
+    expect(screen.getByText('Settings Content')).toBeInTheDocument();
+  });
+
+  it('applies the background prop as the bg style', () => {
+    render(
+      <SettingsBox background="red.500" data-testid="settings-box">
+        <span>Content</span>
+      </SettingsBox>,
+    );
+
+    const box = screen.getByTestId('settings-box');
+    expect(box).toBeInTheDocument();
+  });
+
+  it('forwards additional Flex props', () => {
+    render(
+      <SettingsBox data-testid="settings-box" aria-label="my settings">
+        <span>Content</span>
+      </SettingsBox>,
+    );
+
+    const box = screen.getByTestId('settings-box');
+    expect(box).toHaveAttribute('aria-label', 'my settings');
+  });
+});

--- a/src/app/components/ui/__tests__/TextTooltip.test.tsx
+++ b/src/app/components/ui/__tests__/TextTooltip.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+
+import { render, screen } from '../../../../test/utils';
+import TextTooltip from '../TextTooltip';
+
+describe('TextTooltip', () => {
+  it('renders the text content', () => {
+    render(<TextTooltip text="Hover me" />);
+
+    expect(screen.getByText('Hover me')).toBeInTheDocument();
+  });
+
+  it('uses the label as the aria-label when no content is provided', () => {
+    render(<TextTooltip text="Hover me" label="A helpful label" />);
+
+    expect(screen.getByText('Hover me')).toBeInTheDocument();
+    // The tooltip trigger renders the visible text; the tooltip content is
+    // portalled and only mounted on interaction, so we assert on the
+    // rendered trigger element having the underlying text.
+    expect(screen.getByText('Hover me').closest('p')).toBeInTheDocument();
+  });
+
+  it('renders children as plain text when text is a string', () => {
+    render(<TextTooltip text="Plain text label" />);
+
+    const el = screen.getByText('Plain text label');
+    expect(el).toBeInTheDocument();
+  });
+
+  it('renders custom cursor and textDecoration styles without throwing', () => {
+    render(<TextTooltip text="Styled text" cursor="pointer" textDecoration="underline" />);
+
+    expect(screen.getByText('Styled text')).toBeInTheDocument();
+  });
+
+  it('renders ReactNode text content correctly', () => {
+    render(<TextTooltip text={<span data-testid="node-text">Node content</span>} />);
+
+    expect(screen.getByTestId('node-text')).toBeInTheDocument();
+    expect(screen.getByText('Node content')).toBeInTheDocument();
+  });
+});

--- a/src/app/components/ui/__tests__/TopProgressBar.test.tsx
+++ b/src/app/components/ui/__tests__/TopProgressBar.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { render } from '../../../../test/utils';
+import { useIsRoundOver } from '../../../hooks/useIsRoundOver';
+import { useRoundProgress } from '../../../hooks/useRoundProgress';
+import TopProgressBar from '../TopProgressBar';
+
+vi.mock('../../../hooks/useIsRoundOver', () => ({
+  useIsRoundOver: vi.fn(),
+}));
+
+vi.mock('../../../hooks/useRoundProgress', () => ({
+  useRoundProgress: vi.fn(),
+}));
+
+const mockUseIsRoundOver = vi.mocked(useIsRoundOver);
+const mockUseRoundProgress = vi.mocked(useRoundProgress);
+
+describe('TopProgressBar', () => {
+  it('renders nothing when the round is over', () => {
+    mockUseIsRoundOver.mockReturnValue(true);
+    mockUseRoundProgress.mockReturnValue(50);
+
+    const { container } = render(<TopProgressBar />);
+
+    expect(container.querySelector('[role="progressbar"]')).not.toBeInTheDocument();
+  });
+
+  it('renders the progress bar when the round is not over', () => {
+    mockUseIsRoundOver.mockReturnValue(false);
+    mockUseRoundProgress.mockReturnValue(42);
+
+    const { container } = render(<TopProgressBar />);
+
+    expect(container).not.toBeEmptyDOMElement();
+    const progressRoot = container.querySelector('[role="progressbar"]');
+    expect(progressRoot).toBeInTheDocument();
+  });
+
+  it('renders with a null progress value when round percent is 100 or more', () => {
+    mockUseIsRoundOver.mockReturnValue(false);
+    mockUseRoundProgress.mockReturnValue(100);
+
+    const { container } = render(<TopProgressBar />);
+
+    const progressRoot = container.querySelector('[role="progressbar"]');
+    expect(progressRoot).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Phase 4.1 of the test-coverage expansion effort (Phase 0: #899, Phase 1: #902, Phase 2.1/2.2/2.3: #905/#907/#909, Phase 3: #913).
- Adds 28 tests across 8 new files covering src/app/components/format/DateFormatter.tsx, tables/Td.tsx, and six pure ui/ components (ErrorBoundary, GitCommit, GlowCard, SettingsBox, TextTooltip, TopProgressBar).
- This branch is independent of the other open phase PRs (built from master) so it can be reviewed/merged in any order.

## Notes
- typecheck/lint clean (same pre-existing unrelated errors as before, untouched).