### PR TITLE
Add unit tests for pure TableSettings components and the help module

### DIFF
--- a/src/app/components/TableSettings/__tests__/ColorModeToggle.test.tsx
+++ b/src/app/components/TableSettings/__tests__/ColorModeToggle.test.tsx
@@ -1,0 +1,69 @@
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { render, screen } from '../../../../test/utils';
+import ColorModeToggle from '../ColorModeToggle';
+
+const cookiesSetMock = vi.fn();
+
+// Mock universal-cookie following this repo's established convention
+// (see src/app/__tests__/hashchange.test.ts).
+vi.mock('universal-cookie', () => ({
+  default: vi.fn().mockImplementation(function () {
+    return {
+      get: vi.fn().mockReturnValue(undefined),
+      set: cookiesSetMock,
+    };
+  }),
+}));
+
+class ResizeObserverMock {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+
+describe('ColorModeToggle', () => {
+  beforeEach(() => {
+    cookiesSetMock.mockClear();
+  });
+
+  it('renders the three theme options', () => {
+    render(<ColorModeToggle />);
+
+    expect(screen.getByText('Light')).toBeInTheDocument();
+    expect(screen.getByText('Dark')).toBeInTheDocument();
+    expect(screen.getByText('Night')).toBeInTheDocument();
+  });
+
+  it('reflects the currently active color mode as the selected segment', () => {
+    render(<ColorModeToggle />);
+
+    // ColorModeProvider defaults to "dark".
+    const darkRadio = screen.getByDisplayValue('dark') as HTMLInputElement;
+    expect(darkRadio.checked).toBe(true);
+  });
+
+  it('calls setColorMode (reflected via data-theme) and sets a colorMode cookie when a new option is chosen', async () => {
+    const user = userEvent.setup();
+    render(<ColorModeToggle />);
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+
+    await user.click(screen.getByText('Light'));
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    expect(cookiesSetMock).toHaveBeenCalledWith('colorMode', 'light');
+  });
+
+  it('does not call setColorMode/cookies.set when clicking the already active option', async () => {
+    const user = userEvent.setup();
+    render(<ColorModeToggle />);
+
+    await user.click(screen.getByText('Dark'));
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    expect(cookiesSetMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/components/TableSettings/__tests__/SegmentedSettingsRow.test.tsx
+++ b/src/app/components/TableSettings/__tests__/SegmentedSettingsRow.test.tsx
@@ -1,0 +1,101 @@
+import userEvent from '@testing-library/user-event';
+import { FaGear } from 'react-icons/fa6';
+import { describe, it, expect, vi } from 'vitest';
+
+import { render, screen } from '../../../../test/utils';
+import { SegmentedSettingsRow } from '../SegmentedSettingsRow';
+
+class ResizeObserverMock {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+
+const OPTIONS = [
+  { value: 'first', label: 'First' },
+  { value: 'second', label: 'Second' },
+] as const;
+
+describe('SegmentedSettingsRow', () => {
+  it('renders the label and icon', () => {
+    render(
+      <SegmentedSettingsRow
+        icon={FaGear}
+        label="My Setting"
+        value="first"
+        options={[...OPTIONS]}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('My Setting')).toBeInTheDocument();
+  });
+
+  it('renders all options', () => {
+    render(
+      <SegmentedSettingsRow
+        icon={FaGear}
+        label="My Setting"
+        value="first"
+        options={[...OPTIONS]}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('First')).toBeInTheDocument();
+    expect(screen.getByText('Second')).toBeInTheDocument();
+  });
+
+  it('calls onChange with the new value when a different option is selected', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <SegmentedSettingsRow
+        icon={FaGear}
+        label="My Setting"
+        value="first"
+        options={[...OPTIONS]}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByText('Second'));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('second');
+  });
+
+  it('does not call onChange when re-selecting the already active option (null nextValue guard)', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <SegmentedSettingsRow
+        icon={FaGear}
+        label="My Setting"
+        value="first"
+        options={[...OPTIONS]}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByText('First'));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('applies the provided testId to the segment group root', () => {
+    render(
+      <SegmentedSettingsRow
+        icon={FaGear}
+        label="My Setting"
+        value="first"
+        options={[...OPTIONS]}
+        onChange={vi.fn()}
+        testId="my-segmented-row"
+      />,
+    );
+
+    expect(screen.getByTestId('my-segmented-row')).toBeInTheDocument();
+  });
+});

--- a/src/app/components/TableSettings/__tests__/SettingsRow.test.tsx
+++ b/src/app/components/TableSettings/__tests__/SettingsRow.test.tsx
@@ -1,0 +1,83 @@
+import userEvent from '@testing-library/user-event';
+import { FaGear } from 'react-icons/fa6';
+import { describe, it, expect, vi } from 'vitest';
+
+import { render, screen } from '../../../../test/utils';
+import SettingsRow from '../SettingsRow';
+
+describe('SettingsRow', () => {
+  it('renders the label and icon', () => {
+    render(
+      <SettingsRow
+        icon={FaGear}
+        label="Enable Feature"
+        colorPalette="blue"
+        isChecked={false}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Enable Feature')).toBeInTheDocument();
+  });
+
+  it('calls onChange reflecting the toggled checked value when unchecked -> checked', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <SettingsRow
+        icon={FaGear}
+        label="Enable Feature"
+        colorPalette="blue"
+        isChecked={false}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByText('Enable Feature'));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const event = onChange.mock.calls[0]?.[0];
+    expect(event.target.checked).toBe(true);
+    expect(event.currentTarget.checked).toBe(true);
+  });
+
+  it('calls onChange reflecting the toggled checked value when checked -> unchecked', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <SettingsRow
+        icon={FaGear}
+        label="Enable Feature"
+        colorPalette="blue"
+        isChecked={true}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByText('Enable Feature'));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const event = onChange.mock.calls[0]?.[0];
+    expect(event.target.checked).toBe(false);
+    expect(event.currentTarget.checked).toBe(false);
+  });
+
+  it('does not call onChange when disabled', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <SettingsRow
+        icon={FaGear}
+        label="Enable Feature"
+        colorPalette="blue"
+        isChecked={false}
+        onChange={onChange}
+        disabled
+      />,
+    );
+
+    await user.click(screen.getByText('Enable Feature'));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/components/TableSettings/__tests__/SettingsSwitch.test.tsx
+++ b/src/app/components/TableSettings/__tests__/SettingsSwitch.test.tsx
@@ -1,0 +1,80 @@
+import userEvent from '@testing-library/user-event';
+import { FaGear } from 'react-icons/fa6';
+import { describe, it, expect, vi } from 'vitest';
+
+import { render, screen } from '../../../../test/utils';
+import SettingsSwitch from '../SettingsSwitch';
+
+describe('SettingsSwitch', () => {
+  it('renders the label and icon via SettingsRow delegation', () => {
+    render(
+      <SettingsSwitch
+        icon={FaGear}
+        label="My Switch"
+        colorPalette="blue"
+        checked={false}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('My Switch')).toBeInTheDocument();
+  });
+
+  it('does not crash when tooltipText is omitted and forwards click behavior normally', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <SettingsSwitch
+        icon={FaGear}
+        label="My Switch"
+        colorPalette="blue"
+        checked={false}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByText('My Switch'));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not crash when tooltipText is provided and still forwards click behavior normally', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <SettingsSwitch
+        icon={FaGear}
+        label="My Switch"
+        colorPalette="blue"
+        checked={false}
+        onChange={onChange}
+        tooltipText="Some helpful text"
+      />,
+    );
+
+    expect(screen.getByText('My Switch')).toBeInTheDocument();
+
+    await user.click(screen.getByText('My Switch'));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects the disabled prop', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <SettingsSwitch
+        icon={FaGear}
+        label="My Switch"
+        colorPalette="blue"
+        checked={false}
+        onChange={onChange}
+        disabled
+      />,
+    );
+
+    await user.click(screen.getByText('My Switch'));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/components/help/__tests__/GlossaryRef.test.tsx
+++ b/src/app/components/help/__tests__/GlossaryRef.test.tsx
@@ -1,0 +1,52 @@
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+
+import { render, screen } from '../../../../test/utils';
+import { GlossaryRef } from '../GlossaryRef';
+import { HelpGuideNavigationProvider } from '../HelpGuideNavigationContext';
+
+describe('GlossaryRef', () => {
+  it('renders as a non-interactive span when not inside a HelpGuideNavigationContext provider', () => {
+    render(<GlossaryRef id="odds">odds</GlossaryRef>);
+
+    const el = screen.getByText('odds');
+    expect(el.tagName.toLowerCase()).toBe('span');
+  });
+
+  it('does not invoke any navigation when clicked outside a provider', async () => {
+    const user = userEvent.setup();
+    render(<GlossaryRef id="odds">odds</GlossaryRef>);
+
+    // Should not throw when clicked, since there's no click handler attached.
+    await user.click(screen.getByText('odds'));
+
+    expect(screen.getByText('odds')).toBeInTheDocument();
+  });
+
+  it('renders as a clickable button when inside a HelpGuideNavigationContext provider', () => {
+    const navigate = vi.fn();
+    render(
+      <HelpGuideNavigationProvider value={navigate}>
+        <GlossaryRef id="odds">odds</GlossaryRef>
+      </HelpGuideNavigationProvider>,
+    );
+
+    const el = screen.getByText('odds');
+    expect(el.tagName.toLowerCase()).toBe('button');
+  });
+
+  it('calls the navigate function with the given id when clicked inside a provider', async () => {
+    const user = userEvent.setup();
+    const navigate = vi.fn();
+    render(
+      <HelpGuideNavigationProvider value={navigate}>
+        <GlossaryRef id="odds-timeline">odds timeline</GlossaryRef>
+      </HelpGuideNavigationProvider>,
+    );
+
+    await user.click(screen.getByText('odds timeline'));
+
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith('odds-timeline');
+  });
+});

--- a/src/app/components/help/__tests__/HelpGuideModal.test.tsx
+++ b/src/app/components/help/__tests__/HelpGuideModal.test.tsx
@@ -1,0 +1,81 @@
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+
+import { render, screen } from '../../../../test/utils';
+import { HelpGuideModal } from '../HelpGuideModal';
+
+class ResizeObserverMock {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+
+describe('HelpGuideModal', () => {
+  it('renders nothing visible when isOpen is false', () => {
+    render(<HelpGuideModal isOpen={false} onClose={vi.fn()} initialTab="glossary" />);
+
+    expect(screen.queryByTestId('help-guide-modal')).not.toBeInTheDocument();
+  });
+
+  it('shows modal content when isOpen is true', () => {
+    render(<HelpGuideModal isOpen={true} onClose={vi.fn()} initialTab="glossary" />);
+
+    expect(screen.getByTestId('help-guide-modal')).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Help guide')).toBeInTheDocument();
+  });
+
+  it('respects the initialTab prop - glossary', () => {
+    render(<HelpGuideModal isOpen={true} onClose={vi.fn()} initialTab="glossary" />);
+
+    expect(screen.getByTestId('help-guide-glossary')).toBeInTheDocument();
+    expect(screen.queryByTestId('help-guide-faq')).not.toBeInTheDocument();
+  });
+
+  it('respects the initialTab prop - faq', () => {
+    render(<HelpGuideModal isOpen={true} onClose={vi.fn()} initialTab="faq" />);
+
+    expect(screen.getByTestId('help-guide-faq')).toBeInTheDocument();
+    expect(screen.queryByTestId('help-guide-glossary')).not.toBeInTheDocument();
+  });
+
+  it('switches tabs when a different segment is selected', async () => {
+    const user = userEvent.setup();
+    render(<HelpGuideModal isOpen={true} onClose={vi.fn()} initialTab="glossary" />);
+
+    expect(screen.getByTestId('help-guide-glossary')).toBeInTheDocument();
+
+    await user.click(screen.getByText('FAQs'));
+
+    expect(screen.getByTestId('help-guide-faq')).toBeInTheDocument();
+    expect(screen.queryByTestId('help-guide-glossary')).not.toBeInTheDocument();
+  });
+
+  it('calls onClose when the close button is clicked', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<HelpGuideModal isOpen={true} onClose={onClose} initialTab="glossary" />);
+
+    await user.click(screen.getByTestId('help-guide-close'));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when the footer Close button is clicked', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<HelpGuideModal isOpen={true} onClose={onClose} initialTab="glossary" />);
+
+    const closeButtons = screen.getAllByRole('button', { name: 'Close' });
+    const footerCloseButton = closeButtons.find(
+      button => button.getAttribute('data-testid') !== 'help-guide-close',
+    );
+    if (!footerCloseButton) {
+      throw new Error('Footer close button not found');
+    }
+    await user.click(footerCloseButton);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/components/help/__tests__/HelpGuideNavigationContext.test.tsx
+++ b/src/app/components/help/__tests__/HelpGuideNavigationContext.test.tsx
@@ -1,0 +1,28 @@
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  useHelpGuideNavigation,
+  HelpGuideNavigationProvider,
+  type HelpGuideNavigateToEntry,
+} from '../HelpGuideNavigationContext';
+
+describe('useHelpGuideNavigation', () => {
+  it('returns null outside of a provider', () => {
+    const { result } = renderHook(() => useHelpGuideNavigation());
+
+    expect(result.current).toBeNull();
+  });
+
+  it('returns the provided function value inside a HelpGuideNavigationProvider', () => {
+    const navigate: HelpGuideNavigateToEntry = vi.fn();
+    const wrapper = ({ children }: { children: ReactNode }): ReactNode => (
+      <HelpGuideNavigationProvider value={navigate}>{children}</HelpGuideNavigationProvider>
+    );
+
+    const { result } = renderHook(() => useHelpGuideNavigation(), { wrapper });
+
+    expect(result.current).toBe(navigate);
+  });
+});

--- a/src/app/components/help/__tests__/HelpGuideProvider.test.tsx
+++ b/src/app/components/help/__tests__/HelpGuideProvider.test.tsx
@@ -1,0 +1,73 @@
+import userEvent from '@testing-library/user-event';
+import type { ReactElement } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { render, screen } from '../../../../test/utils';
+import { HelpGuideProvider, useHelpGuide } from '../HelpGuideProvider';
+
+class ResizeObserverMock {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+
+const ThrowingConsumer = (): null => {
+  useHelpGuide();
+  return null;
+};
+
+const OpenGlossaryButton = (): ReactElement => {
+  const { openHelpGuide } = useHelpGuide();
+  return <button onClick={() => openHelpGuide()}>Open Help</button>;
+};
+
+const OpenFaqEntryButton = (): ReactElement => {
+  const { openHelpGuide } = useHelpGuide();
+  return <button onClick={() => openHelpGuide('faq', 'trophies')}>Open FAQ Entry</button>;
+};
+
+describe('useHelpGuide', () => {
+  it('throws when called outside of a HelpGuideProvider', () => {
+    // Suppress the expected React error boundary console noise for this assertion.
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    expect(() => render(<ThrowingConsumer />)).toThrow(
+      'useHelpGuide must be used within HelpGuideProvider',
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+});
+
+describe('HelpGuideProvider', () => {
+  it('opens the modal on the default glossary tab when openHelpGuide() is called with no args', async () => {
+    const user = userEvent.setup();
+    render(
+      <HelpGuideProvider>
+        <OpenGlossaryButton />
+      </HelpGuideProvider>,
+    );
+
+    expect(screen.queryByTestId('help-guide-modal')).not.toBeInTheDocument();
+
+    await user.click(screen.getByText('Open Help'));
+
+    expect(screen.getByTestId('help-guide-modal')).toBeInTheDocument();
+    expect(screen.getByTestId('help-guide-glossary')).toBeInTheDocument();
+  });
+
+  it('opens the modal on the requested tab/entry when openHelpGuide(tab, entryId) is called', async () => {
+    const user = userEvent.setup();
+    render(
+      <HelpGuideProvider>
+        <OpenFaqEntryButton />
+      </HelpGuideProvider>,
+    );
+
+    await user.click(screen.getByText('Open FAQ Entry'));
+
+    expect(screen.getByTestId('help-guide-modal')).toBeInTheDocument();
+    expect(screen.getByTestId('help-guide-faq')).toBeInTheDocument();
+  });
+});

--- a/src/app/components/help/__tests__/HelpOddsTimelineExample.test.tsx
+++ b/src/app/components/help/__tests__/HelpOddsTimelineExample.test.tsx
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+
+import { render, screen } from '../../../../test/utils';
+import { HelpOddsTimelineExample } from '../HelpOddsTimelineExample';
+
+describe('HelpOddsTimelineExample', () => {
+  it('renders without throwing and produces visible output', () => {
+    render(<HelpOddsTimelineExample />);
+
+    expect(screen.getByRole('img', { name: 'Example odds timeline' })).toBeInTheDocument();
+  });
+});

--- a/src/app/components/help/__tests__/glossaryContentHelpers.test.tsx
+++ b/src/app/components/help/__tests__/glossaryContentHelpers.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+
+import { render, screen } from '../../../../test/utils';
+import { seeGlossary, GlossaryFormula } from '../glossaryContentHelpers';
+
+describe('seeGlossary', () => {
+  it('includes the given term in the rendered text', () => {
+    render(<div>{seeGlossary('Bust rate')}</div>);
+
+    expect(screen.getByText(/See the Glossary entry for/)).toBeInTheDocument();
+    expect(screen.getByText(/Bust rate/)).toBeInTheDocument();
+  });
+});
+
+describe('GlossaryFormula', () => {
+  it('renders its children inside a code element', () => {
+    render(<GlossaryFormula>ER = odds x probability</GlossaryFormula>);
+
+    const formula = screen.getByText('ER = odds x probability');
+    expect(formula.tagName.toLowerCase()).toBe('code');
+  });
+});


### PR DESCRIPTION
## Summary
- Phase 4.2 of the test-coverage expansion effort (Phase 0: #899, Phase 1: #902, Phase 2.1/2.2/2.3: #905/#907/#909, Phase 3: #913, Phase 4.1: #914). Completes Phase 4.
- Adds 36 tests across 10 new files covering SegmentedSettingsRow, SettingsRow, SettingsSwitch, ColorModeToggle, and the six help/ components (GlossaryRef, HelpGuideProvider, HelpGuideNavigationContext, HelpGuideModal, HelpOddsTimelineExample, glossaryContentHelpers).
- Note: rendering Chakra's SegmentGroup triggers a ResizeObserver construction that the shared src/test/setup.ts mocks as a non-constructible arrow function. Rather than touch the shared setup file, the three affected test files here locally override the global via vi.stubGlobal with a proper constructible class, scoped to those files only.
- This branch is independent of the other open phase PRs (built from master) so it can be reviewed/merged in any order.

## Notes
- typecheck/lint clean (same pre-existing unrelated errors as before, untouched).