### PR TITLE
Remove redundant hover override on Place Bet button

### DIFF
--- a/src/app/components/bets/PlaceThisBetButton.tsx
+++ b/src/app/components/bets/PlaceThisBetButton.tsx
@@ -90,7 +90,6 @@ const ActivePlaceBetButton = React.memo(
         colorPalette="nfc-green"
         variant="surface"
         opacity={clicked ? 0.5 : 1}
-        _hover={{ bg: 'colorPalette.emphasized' }}
       >
         {clicked ? 'Bet placed!' : 'Place bet!'} <FaExternalLinkAlt />
       </BetButton>


### PR DESCRIPTION
## Summary
- The surface button variant's recipe already defines `_hover: { bg: 'colorPalette.muted' }`, and theme.ts now gives nfc-* palettes a distinct muted shade (#915), so the Place Bet button no longer needs its own hover override
- Removes `_hover={{ bg: 'colorPalette.emphasized' }}` from PlaceThisBetButton.tsx, letting it fall back to the recipe default like every other surface button