### PR TITLE
Fix bet-share links losing all picks after the wasm engine port

### DIFF
--- a/src/app/__tests__/wasmInitOrder.test.ts
+++ b/src/app/__tests__/wasmInitOrder.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock universal-cookie before any store imports (same as hashchange.test.ts)
+vi.mock('universal-cookie', () => ({
+  default: vi.fn().mockImplementation(function () {
+    return {
+      get: vi.fn().mockReturnValue(undefined),
+      set: vi.fn(),
+    };
+  }),
+}));
+
+const BET_HASH = 'sjaqwsjntuqjequnjeqpsicqp';
+const ROUND = 9927;
+
+function setHash(hash: string): void {
+  Object.defineProperty(window, 'location', {
+    writable: true,
+    value: { ...window.location, hash: `#${hash}` },
+  });
+}
+
+/**
+ * Regression test for the bet-link-loses-all-picks bug: the wasm module is
+ * loaded asynchronously (initWasmMath(), awaited in src/index.jsx right
+ * before the app mounts), but betStore/roundStore used to parse the URL
+ * hash at module-eval time - which, in the real app, always runs *before*
+ * that await resolves (static imports execute before any code in the
+ * importing module's own body, including code after a top-level await).
+ * getWasm() would throw, parseBets/parseBetAmounts would silently catch it
+ * and fall back to empty bets, and the bet grid would render empty on
+ * every single bet-link load - the round parsed fine (no wasm involved)
+ * but the picks were always gone.
+ *
+ * This test drives the exact same not-ready -> ready transition with a
+ * controllable wasm mock instead of a real build, so it exercises the real
+ * failure mode without requiring wasm-pack.
+ */
+describe('bet URL parsing vs. wasm init ordering', () => {
+  let wasmReady = false;
+
+  beforeEach(() => {
+    vi.resetModules();
+    wasmReady = false;
+    setHash(`round=${ROUND}&b=${BET_HASH}`);
+
+    vi.doMock('../wasmMath', () => {
+      const requireReady = (): void => {
+        if (!wasmReady) {
+          throw new Error(
+            'neofoodclub-wasm module not initialized - initWasmMath() must be awaited before use',
+          );
+        }
+      };
+
+      // Minimal re-implementation of the legacy hand-rolled hash codec,
+      // just so the "ready" path decodes something real to assert against.
+      const ALPHABET = 'abcdefghijklmnopqrstuvwxy';
+      const wasmBetsHashToIndices = (hash: string): number[] => {
+        requireReady();
+        return hash
+          .replace(/[^a-y]/g, '')
+          .split('')
+          .flatMap(char => {
+            const n = ALPHABET.indexOf(char);
+            return [Math.floor(n / 5), n % 5];
+          });
+      };
+      const wasmAmountsHashToBetAmounts = (_hash: string, betAmountDefault: number): number[] => (
+        requireReady(),
+        Array.from({ length: 10 }, () => betAmountDefault)
+      );
+      const wasmBetsIndicesToHash = (): string => (requireReady(), '');
+      const wasmBetAmountsToAmountsHash = (): string => (requireReady(), '');
+
+      return {
+        initWasmMath: vi.fn(),
+        wasmBetsHashToIndices,
+        wasmAmountsHashToBetAmounts,
+        wasmBetsIndicesToHash,
+        wasmBetAmountsToAmountsHash,
+      };
+    });
+  });
+
+  afterEach(() => {
+    vi.doUnmock('../wasmMath');
+  });
+
+  it('does not eagerly parse the URL at module-eval time (before wasm is ready)', async () => {
+    const { useBetStore } = await import('../stores/betStore');
+    const { useRoundStore } = await import('../stores/roundStore');
+
+    // wasm was never marked ready - if the store parsed eagerly at import
+    // time, this would have thrown internally and landed on the exact same
+    // "empty" state, so the real assertion is in the next test: hydrating
+    // *after* wasm becomes ready must still work. Here we just confirm the
+    // module import itself didn't blow up and produced safe defaults.
+    const betState = useBetStore.getState();
+    expect(betState.allBets.get(0)?.get(1)).toEqual([0, 0, 0, 0, 0]);
+
+    const roundState = useRoundStore.getState();
+    expect(roundState.currentSelectedRound).toBe(0);
+    expect(roundState.viewMode).toBe(false);
+  });
+
+  it('correctly decodes the URL once hydrated after wasm becomes ready', async () => {
+    const { useBetStore, hydrateBetStoreFromUrl } = await import('../stores/betStore');
+    const { useRoundStore, hydrateRoundStoreFromUrl } = await import('../stores/roundStore');
+
+    // Simulate initWasmMath() resolving, then index.jsx's post-await hydrate calls.
+    wasmReady = true;
+    hydrateBetStoreFromUrl();
+    hydrateRoundStoreFromUrl();
+
+    const roundState = useRoundStore.getState();
+    expect(roundState.currentSelectedRound).toBe(ROUND);
+    expect(roundState.viewMode).toBe(true);
+
+    const betState = useBetStore.getState();
+    const firstBet = betState.allBets.get(0)?.get(1);
+    expect(firstBet).toBeDefined();
+    expect(firstBet?.some(pirate => pirate > 0)).toBe(true);
+  });
+});

--- a/src/app/stores/betStore.ts
+++ b/src/app/stores/betStore.ts
@@ -45,23 +45,41 @@ interface BetStore {
   clearAllBets: () => void;
 }
 
-// Parse initial state from URL
-let initialState: { round: number; bets: Bet; betAmounts: BetAmount };
-try {
-  initialState = parseBetUrl(window.location.hash.slice(1));
-  if (initialState.bets.size === 0) {
-    initialState.bets = makeEmptyBets(10);
+// Safe, synchronous defaults - do NOT parse the URL here. parseBetUrl decodes
+// the `b=`/`a=` hash fragments via the wasm engine (see util.ts), which isn't
+// initialized yet at module-eval time (src/index.jsx awaits initWasmMath()
+// after this module has already been imported and evaluated). Parsing here
+// would silently decode to empty bets every time. The real parse happens in
+// hydrateBetStoreFromUrl(), called from index.jsx once wasm is ready.
+const initialState: { round: number; bets: Bet; betAmounts: BetAmount } = {
+  round: 0,
+  bets: makeEmptyBets(10),
+  betAmounts: makeEmptyBetAmounts(10),
+};
+
+/**
+ * Parses the current URL hash and applies it to the store. Must only be
+ * called after initWasmMath() has resolved (see src/index.jsx) - calling it
+ * earlier will silently decode to empty bets, since parseBetUrl depends on
+ * the wasm engine being initialized.
+ */
+export function hydrateBetStoreFromUrl(): void {
+  let bets: Bet;
+  let betAmounts: BetAmount;
+  try {
+    const parsed = parseBetUrl(window.location.hash.slice(1));
+    bets = parsed.bets.size === 0 ? makeEmptyBets(10) : parsed.bets;
+    betAmounts = parsed.betAmounts.size === 0 ? makeEmptyBetAmounts(10) : parsed.betAmounts;
+  } catch (error) {
+    console.error('Failed to parse initial bet URL:', error);
+    bets = makeEmptyBets(10);
+    betAmounts = makeEmptyBetAmounts(10);
   }
-  if (initialState.betAmounts.size === 0) {
-    initialState.betAmounts = makeEmptyBetAmounts(10);
-  }
-} catch (error) {
-  console.error('Failed to parse initial bet URL:', error);
-  initialState = {
-    round: 0,
-    bets: makeEmptyBets(10),
-    betAmounts: makeEmptyBetAmounts(10),
-  };
+
+  useBetStore.setState(state => ({
+    allBets: new Map(state.allBets).set(0, bets),
+    allBetAmounts: new Map(state.allBetAmounts).set(0, betAmounts),
+  }));
 }
 
 export const useBetStore = create<BetStore>()(

--- a/src/app/stores/roundStore.ts
+++ b/src/app/stores/roundStore.ts
@@ -139,28 +139,32 @@ interface RoundStore {
   initialize: () => Promise<void>;
 }
 
-const initialState = parseBetUrl(window.location.hash.slice(1));
+// Do NOT parse the URL here - parseBetUrl decodes the `b=`/`a=` hash via the
+// wasm engine (see util.ts), which isn't initialized yet at module-eval time
+// (src/index.jsx awaits initWasmMath() after this module has already been
+// imported and evaluated). Start with safe defaults; hydrateRoundStoreFromUrl(),
+// called from index.jsx once wasm is ready, applies the real parsed values.
 
 export const useRoundStore = create<RoundStore>()(
   subscribeWithSelector((set, get) => ({
     // Round data
     roundData: defaultRoundData,
-    currentRound: initialState.round || 0,
-    currentSelectedRound: initialState.round || 0,
+    currentRound: 0,
+    currentSelectedRound: 0,
 
     // Settings
     customOdds: null,
     customProbs: null,
     tableMode: getTableMode(),
     betSetPosition: getBetSetPosition(),
-    viewMode: anyBetsExist(initialState.bets),
+    viewMode: false,
     useWebDomain: getUseWebDomain(),
     bigBrain: getBigBrainMode(),
     faDetails: getFaDetailsMode(),
     customOddsMode: getCustomOddsMode(),
     oddsTimeline: getOddsTimelineMode(),
     useLogitModel: getUseLogitModel(),
-    maxBet: getMaxBet(initialState.round || 0),
+    maxBet: getMaxBet(0),
 
     // Calculations
     calculations: emptyCalculations,
@@ -700,6 +704,24 @@ export const useRoundStore = create<RoundStore>()(
     },
   })),
 );
+
+/**
+ * Parses the current URL hash and applies the round/view-mode/max-bet it
+ * encodes. Must only be called after initWasmMath() has resolved (see
+ * src/index.jsx) - calling it earlier will silently see no bets (round still
+ * parses fine, since it doesn't touch the wasm engine), since parseBetUrl's
+ * bet/amount decoding depends on the wasm engine being initialized.
+ */
+export function hydrateRoundStoreFromUrl(): void {
+  const initialState = parseBetUrl(window.location.hash.slice(1));
+  const round = initialState.round || 0;
+  useRoundStore.setState({
+    currentRound: round,
+    currentSelectedRound: round,
+    viewMode: anyBetsExist(initialState.bets),
+    maxBet: getMaxBet(round),
+  });
+}
 
 // Subscribe to bet changes and recalculate
 // Use dynamic import to avoid circular dependency at module load time

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -7,6 +7,8 @@ import './index.css';
 import App from './app/App';
 import DropZone from './app/DropZone';
 import FaviconGenerator from './app/FaviconGenerator';
+import { hydrateBetStoreFromUrl } from './app/stores/betStore';
+import { hydrateRoundStoreFromUrl } from './app/stores/roundStore';
 import { initWasmMath } from './app/wasmMath';
 
 import { Provider } from '@/components/ui/provider';
@@ -34,6 +36,13 @@ if ('serviceWorker' in navigator) {
 // into src/app/maths.ts - including ones made from useMemo in render bodies -
 // is safe from the very first render.
 await initWasmMath();
+
+// Parse the URL hash now that the wasm engine is ready. Doing this at
+// betStore/roundStore module-eval time (before this await resolves) would
+// silently decode to empty bets - the store modules are statically imported
+// above, so their top-level code already ran before this line.
+hydrateBetStoreFromUrl();
+hydrateRoundStoreFromUrl();
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(


### PR DESCRIPTION
## Summary

- Bet-share links (`#round=X&b=...`) load the correct round but with zero pirates picked. This is a 100%-reproducing regression from the WASM engine port (38c9e89), currently live in production.
- `betStore.ts`/`roundStore.ts` parsed `window.location.hash` at module top-level, but that decoding depends on the wasm engine (`parseBets`/`parseBetAmounts` in `util.ts`). Static imports always finish evaluating before any code in the importing module runs - including code after a top-level `await` - so this parse always ran before `index.jsx`'s `await initWasmMath()` had a chance to resolve. `getWasm()` threw, the per-field try/catch in `parseBetUrl` swallowed it, and bets silently decoded empty every time. The round number still parsed correctly since that part doesn't touch wasm - matching the observed symptom exactly.
- Moves the parse into `hydrateBetStoreFromUrl()`/`hydrateRoundStoreFromUrl()`, called from `index.jsx` right after `initWasmMath()` resolves and before the app mounts, so it only ever runs once wasm is guaranteed ready.
- Adds `wasmInitOrder.test.ts`, a regression test that simulates the not-ready -> ready wasm transition and verifies bets are no longer eagerly (and silently) decoded to empty.