### PR TITLE
Enable automerge for Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,9 @@
   "git-submodules": {
     "enabled": true
   },
+  "automerge": true,
+  "automergeType": "pr",
+  "platformAutomerge": true,
   "packageRules": [
     {
       "matchPackageNames": ["typescript"],


### PR DESCRIPTION
## Summary
- Turn on automerge for Renovate PRs (status checks still gate merge)