### PR TITLE
Show commit hash in tab title for non-production builds

### DIFF
--- a/src/app/Footer.tsx
+++ b/src/app/Footer.tsx
@@ -32,6 +32,7 @@ import { GitCommit } from './components/ui/GitCommit';
 import NeopointIcon from './images/np-icon.svg';
 import { useSelectedRound, useCurrentBet, useAllBets, useAllBetAmounts } from './stores';
 import { makeBetURL } from './util';
+import { isProductionHost } from './util/isProductionHost';
 
 interface LogoProps {
   rotation: number;
@@ -105,10 +106,7 @@ const Footer: React.FC<FooterProps> = props => {
   const allBets = useAllBets();
   const allBetAmounts = useAllBetAmounts();
 
-  const isProductionHost = React.useMemo(() => {
-    const host = window.location.hostname;
-    return host === 'neofood.club' || host === 'www.neofood.club';
-  }, []);
+  const isProdHost = React.useMemo(() => isProductionHost(), []);
 
   const classicHref = React.useMemo(() => {
     const baseUrl = 'https://foodclub.neocities.org';
@@ -266,7 +264,7 @@ const Footer: React.FC<FooterProps> = props => {
               >
                 Source Code
               </FooterLink>
-              {!isProductionHost && (
+              {!isProdHost && (
                 <FooterLink
                   icon={FaGlobe}
                   href={productionHref}

--- a/src/app/util/isProductionHost.ts
+++ b/src/app/util/isProductionHost.ts
@@ -1,0 +1,4 @@
+export function isProductionHost(): boolean {
+  const host = window.location.hostname;
+  return host === 'neofood.club' || host === 'www.neofood.club';
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -9,6 +9,7 @@ import DropZone from './app/DropZone';
 import FaviconGenerator from './app/FaviconGenerator';
 import { hydrateBetStoreFromUrl } from './app/stores/betStore';
 import { hydrateRoundStoreFromUrl } from './app/stores/roundStore';
+import { isProductionHost } from './app/util/isProductionHost';
 import { initWasmMath } from './app/wasmMath';
 
 import { Provider } from '@/components/ui/provider';
@@ -17,6 +18,14 @@ import { Provider } from '@/components/ui/provider';
 window.ENV = {
   VITE_GIT_COMMIT_SHA: import.meta.env.VITE_GIT_COMMIT_SHA,
 };
+
+// Non-production builds show the commit hash in the tab title so it's
+// obvious which deploy is being viewed.
+if (!isProductionHost()) {
+  const commitHash = import.meta.env.VITE_GIT_COMMIT_SHA;
+  const shortHash = commitHash ? commitHash.substring(0, 7) : 'dev';
+  document.title = `NFC [${shortHash}]`;
+}
 
 // Register service worker without automatic updates
 if ('serviceWorker' in navigator) {


### PR DESCRIPTION
## Summary
- Non-production builds now set the tab title to `NFC [{short_commit_hash}]` instead of the default `NeoFoodClub`, using the existing `VITE_GIT_COMMIT_SHA` env var.
- Extracted the production-host check (`neofood.club` / `www.neofood.club`) out of Footer.tsx into `src/app/util/isProductionHost.ts` so it can be reused for the title logic and stays in sync with the footer's own production-link check.