### PR TITLE
Fix opening a shared bet-set link for an old round reverting to current round

### DIFF
--- a/src/app/__tests__/betStoreUrlSyncOnBoot.test.ts
+++ b/src/app/__tests__/betStoreUrlSyncOnBoot.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock universal-cookie before any store imports (same as other store tests)
+vi.mock('universal-cookie', () => ({
+  default: vi.fn().mockImplementation(function () {
+    return {
+      get: vi.fn().mockReturnValue(undefined),
+      set: vi.fn(),
+    };
+  }),
+}));
+
+const BET_HASH = 'sjaqwsjntuqjequnjeqpsicqp';
+const ROUND = 9927;
+
+describe('betStore URL-sync subscriber vs. cold-boot hydration order', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    // Use a real (writable) jsdom location so history.replaceState genuinely
+    // updates window.location.hash, matching real-browser behavior.
+    window.location.hash = `#round=${ROUND}&b=${BET_HASH}`;
+  });
+
+  /**
+   * Regression test for a bug where opening a shared bet-set link for an old
+   * round (with bets) reverted to the current round instead. Root cause:
+   * src/index.jsx calls hydrateBetStoreFromUrl() before hydrateRoundStoreFromUrl().
+   * hydrateBetStoreFromUrl() populates real bets, which fires betStore.ts's
+   * URL-sync subscriber (it only fires when bets actually change - hence this
+   * never reproduced with a bets-less URL). At that point roundStore hasn't
+   * hydrated yet, so both currentSelectedRound and roundData.round are still
+   * their shared startup default of 0 - the subscriber's old guard
+   * (`roundData.round !== currentSelectedRound`) treated 0 === 0 as "in sync"
+   * and rewrote the URL to round=0 using makeBetURL, clobbering the real round
+   * before hydrateRoundStoreFromUrl() ever got to read it. fetchCurrentRound()
+   * would then see currentSelectedRound === 0 and jump to the live round.
+   */
+  it('does not clobber the URL round when bets hydrate before the round store', async () => {
+    // vi.resetModules() gives wasmMath.ts a fresh, not-yet-initialized module
+    // instance, so it must be re-awaited here - matching src/index.jsx's real
+    // "await initWasmMath()" before the hydrate calls.
+    const { initWasmMath } = await import('../wasmMath');
+    await initWasmMath();
+
+    const { hydrateBetStoreFromUrl } = await import('../stores/betStore');
+    const { hydrateRoundStoreFromUrl, useRoundStore } = await import('../stores/roundStore');
+
+    // Exact boot order from src/index.jsx.
+    hydrateBetStoreFromUrl();
+    hydrateRoundStoreFromUrl();
+
+    expect(useRoundStore.getState().currentSelectedRound).toBe(ROUND);
+    expect(window.location.hash).toContain(`round=${ROUND}`);
+    expect(window.location.hash).not.toContain('round=0');
+  });
+});

--- a/src/app/stores/betStore.ts
+++ b/src/app/stores/betStore.ts
@@ -334,9 +334,14 @@ useBetStore.subscribe(
       return;
     }
 
-    // Don't update URL if round data doesn't match selected round (round is switching)
-    // This prevents URL updates during round transitions
-    if (roundState.roundData.round !== roundState.currentSelectedRound) {
+    // Don't update URL before the round store has hydrated from the URL (currentSelectedRound
+    // is still its startup default of 0), or while round data doesn't match the selected round
+    // (round is switching) - otherwise this fires with round 0 and clobbers the real round in
+    // the URL before hydrateRoundStoreFromUrl() has a chance to read it.
+    if (
+      !roundState.currentSelectedRound ||
+      roundState.roundData.round !== roundState.currentSelectedRound
+    ) {
       return;
     }
 


### PR DESCRIPTION
## Summary
- Opening a shared bet-set link for an old round (e.g. `#round=1234&b=...`) would silently jump to the current round instead - reproduced only when the URL included bets, not with a bare `#round=` link.
- Root cause: `betStore.ts`'s URL-sync subscriber guards against rewriting the address bar mid-round-transition by checking `roundData.round !== currentSelectedRound`, but at cold boot both values share the same startup default of `0`, so the guard doesn't fire. `hydrateBetStoreFromUrl()` runs before `hydrateRoundStoreFromUrl()` in `src/index.jsx`, so populating real bets from the URL fires this subscriber and rewrites the URL to `round=0` before the round store ever reads the real round. `fetchCurrentRound()` then sees `currentSelectedRound === 0` and jumps to the live round.
- Fix: the guard now also bails out when `currentSelectedRound` is falsy (not yet hydrated), not just when it mismatches `roundData.round`.

Verified by reproducing the bug against the real production build in an actual browser (Playwright), confirming the fix resolves it, and adding a regression test that fails on the old guard and passes with the fix.