### PR TITLE
Fix Custom Odds not being reflected in per-pirate Payout %

### DIFF
--- a/src/app/__tests__/ArenaTableBody.customOdds.test.tsx
+++ b/src/app/__tests__/ArenaTableBody.customOdds.test.tsx
@@ -1,0 +1,113 @@
+import fs from 'fs';
+import path from 'path';
+
+import { Table } from '@chakra-ui/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { render, screen, act } from '../../test/utils';
+import type { RoundData } from '../../types';
+import ArenaTableBody from '../components/tables/ArenaTableBody';
+import { useBetStore } from '../stores/betStore';
+import { useRoundStore } from '../stores/roundStore';
+
+vi.mock('universal-cookie', () => ({
+  default: vi.fn().mockImplementation(function () {
+    return {
+      get: vi.fn().mockReturnValue(undefined),
+      set: vi.fn(),
+    };
+  }),
+}));
+
+/**
+ * Regression test for the per-pirate "Payout" cell (odds * probability - 1,
+ * ArenaTableBody.tsx's PirateRow) silently ignoring Custom Odds - it read
+ * `currentOdds` directly instead of resolving through Custom Odds mode like
+ * the bet-level Odds/Payoff columns already do via getOdds().
+ */
+describe('ArenaTableBody Payout cell vs Custom Odds', () => {
+  const fixturesPath = path.resolve(__dirname, 'fixtures/rounds.jsonl');
+  const roundData: RoundData = JSON.parse(
+    fs.readFileSync(fixturesPath, 'utf8').trim().split('\n')[0]!,
+  );
+
+  const noop = vi.fn();
+
+  beforeEach(() => {
+    useBetStore.setState({
+      currentBet: 0,
+      allBets: new Map([[0, new Map()]]),
+      allBetAmounts: new Map([[0, new Map()]]),
+      allNames: new Map([[0, 'Test Set']]),
+    });
+  });
+
+  function renderArena(): void {
+    render(
+      <Table.Root>
+        <ArenaTableBody
+          arenaId={0}
+          handleTimelineClick={noop}
+          handleArenaTimelineClick={noop}
+          handleBetLineChange={noop}
+        />
+      </Table.Root>,
+    );
+  }
+
+  it('changes the Payout % for a pirate when Custom Odds are set for that pirate', () => {
+    // Baseline: Big Brain on, Custom Odds mode off - Payout uses real currentOdds.
+    useRoundStore.setState({
+      roundData,
+      currentSelectedRound: roundData.round,
+      currentRound: roundData.round,
+      bigBrain: true,
+      useLogitModel: true, // collapses Min/Max/Std Prob into a single "Prob" cell
+      customOddsMode: false,
+      customOdds: null,
+      customProbs: null,
+    });
+    useRoundStore.getState().recalculate();
+
+    renderArena();
+    const rowBefore = screen.getAllByRole('row')[1]!; // [0] is the arena header row
+    const percentCellsBefore = rowBefore.querySelectorAll('td');
+    // Column order (Big Brain, Logit model, Custom Odds mode off) is:
+    // [pirate name, Prob%, Payout%, FA, ...]. Take the 2nd '%' cell (Payout).
+    const payoutTextBefore = Array.from(percentCellsBefore)
+      .map(td => td.textContent)
+      .filter(text => text?.includes('%'))[1];
+
+    // Now enable Custom Odds mode with a value for pirate 1 (index 0) in arena 0
+    // that differs from its real currentOdds.
+    const realOdds = roundData.currentOdds[0]![1]!;
+    const customOddsValue = realOdds === 2 ? 3 : 2;
+    const customOdds = roundData.currentOdds.map(arena => [...arena]);
+    customOdds[0]![1] = customOddsValue;
+
+    act(() => {
+      useRoundStore.setState({
+        customOddsMode: true,
+        customOdds,
+      });
+      useRoundStore.getState().recalculate();
+    });
+
+    const rowAfter = screen.getAllByRole('row')[1]!;
+    const percentCellsAfter = rowAfter.querySelectorAll('td');
+    // Column order now includes the Custom Prob input before Payout, but
+    // that's a NumberInput (no '%' text node), so Payout is still the 2nd match.
+    const payoutTextAfter = Array.from(percentCellsAfter)
+      .map(td => td.textContent)
+      .filter(text => text?.includes('%'))[1];
+
+    expect(payoutTextAfter).not.toBe(payoutTextBefore);
+
+    // Verify it matches customOddsValue * prob - 1 exactly, using the same
+    // usedProbabilities the component itself reads.
+    const prob = useRoundStore.getState().calculations.usedProbabilities?.[0]?.[1] ?? 0;
+    const expectedPayout = customOddsValue * prob - 1;
+    const expectedText = `${(expectedPayout * 100).toFixed(1)}%`;
+    expect(payoutTextAfter).toBe(expectedText);
+  });
+});

--- a/src/app/__tests__/util.test.ts
+++ b/src/app/__tests__/util.test.ts
@@ -1,9 +1,13 @@
+import fs from 'fs';
+import path from 'path';
+
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-import { RoundState } from '../../types';
+import { RoundData, RoundState } from '../../types';
 import { Bet, BetAmount } from '../../types/bets';
 import { BET_AMOUNT_DEFAULT, BET_AMOUNT_MAX } from '../constants';
 import {
+  calculateRoundData,
   generateRandomIntegerInRange,
   generateRandomPirateIndex,
   displayAsPercent,
@@ -16,6 +20,7 @@ import {
   countNonZeroElements,
   cartesianProduct,
   calculateBaseMaxBet,
+  getOdds,
   isValidRound,
   makeBetURL,
   escapeHtmlText,
@@ -863,6 +868,205 @@ describe('Utility Functions', () => {
     it('handles empty date', () => {
       const result = formatDate('', { fromNow: true });
       expect(result).toBe('');
+    });
+  });
+
+  describe('getOdds', () => {
+    it('returns customOdds when bigBrain and customOddsMode are enabled', () => {
+      const roundState: Partial<RoundState> = {
+        advanced: {
+          bigBrain: true,
+          customOddsMode: true,
+          oddsTimeline: false,
+          faDetails: false,
+          useLogitModel: false,
+        },
+        customOdds: [
+          [1, 12, 4, 6, 22],
+          [1, 26, 4, 6, 6],
+          [1, 26, 4, 12, 10],
+          [1, 26, 26, 4, 26],
+          [1, 26, 4, 26, 12],
+        ],
+      };
+
+      const result = getOdds(roundState);
+      expect(result).toEqual(roundState.customOdds);
+    });
+
+    it('returns currentOdds when customOddsMode is disabled', () => {
+      const roundState: Partial<RoundState> = {
+        roundData: {
+          round: 3574,
+          pirates: [
+            [1, 2, 3, 4],
+            [1, 2, 3, 4],
+          ],
+          currentOdds: [
+            [1, 6, 2, 3, 11],
+            [1, 13, 2, 3, 3],
+          ],
+          openingOdds: [
+            [1, 5, 2, 3, 10],
+            [1, 12, 2, 3, 3],
+          ],
+        },
+        advanced: {
+          bigBrain: true,
+          customOddsMode: false,
+          oddsTimeline: false,
+          faDetails: false,
+          useLogitModel: false,
+        },
+        customOdds: [
+          [1, 12, 4, 6, 22],
+          [1, 26, 4, 6, 6],
+        ],
+      };
+
+      const result = getOdds(roundState);
+      expect(result).toEqual(roundState.roundData.currentOdds);
+    });
+
+    it('returns currentOdds when bigBrain is disabled', () => {
+      const roundState: Partial<RoundState> = {
+        roundData: {
+          round: 3574,
+          pirates: [
+            [1, 2, 3, 4],
+            [1, 2, 3, 4],
+          ],
+          currentOdds: [
+            [1, 6, 2, 3, 11],
+            [1, 13, 2, 3, 3],
+          ],
+          openingOdds: [
+            [1, 5, 2, 3, 10],
+            [1, 12, 2, 3, 3],
+          ],
+        },
+        advanced: {
+          bigBrain: false,
+          customOddsMode: true,
+          oddsTimeline: false,
+          faDetails: false,
+          useLogitModel: false,
+        },
+        customOdds: [
+          [1, 12, 4, 6, 22],
+          [1, 26, 4, 6, 6],
+        ],
+      };
+
+      const result = getOdds(roundState);
+      expect(result).toEqual(roundState.roundData.currentOdds);
+    });
+  });
+
+  describe('calculateRoundData', () => {
+    it('resolves effective odds via getOdds into betOdds/betPayoffs when customOddsMode is enabled', () => {
+      // Read a real round fixture
+      const fixturesPath = path.resolve(__dirname, 'fixtures/rounds.jsonl');
+      const fixtures: { file: string; roundData: RoundData }[] = fs
+        .readFileSync(fixturesPath, 'utf8')
+        .trim()
+        .split('\n')
+        .map(line => JSON.parse(line) as RoundData)
+        .map(roundData => ({ file: `${roundData.round}.json`, roundData }));
+
+      // Use the first fixture (should have valid odds data)
+      const fixture = fixtures[0];
+      expect(fixture?.roundData.currentOdds?.length).toBeGreaterThan(0);
+
+      // Create custom odds that change the bet's target pirate's odds
+      // relative to the rest of its arena (index 0 stays 1, the wasm engine
+      // requires it). Uniformly scaling every pirate in an arena by the same
+      // factor would preserve their relative proportions and leave the
+      // normalized probability unchanged, so only arena 0's pirate 1 (the
+      // pirate this test bets on) is adjusted.
+      const customOdds: number[][] = fixture.roundData.currentOdds.map((arena, arenaIndex) =>
+        arena.map((odd, index) => {
+          if (index === 0) {
+            return 1;
+          }
+          if (arenaIndex === 0 && index === 1) {
+            return Math.min(13, odd * 3);
+          }
+          return odd;
+        }),
+      );
+
+      // Build round state with custom odds mode enabled
+      const roundStateWithCustomOdds: RoundState = {
+        roundData: fixture.roundData,
+        currentSelectedRound: fixture.roundData.round,
+        currentRound: fixture.roundData.round,
+        advanced: {
+          bigBrain: true,
+          faDetails: false,
+          oddsTimeline: false,
+          customOddsMode: true,
+          useLogitModel: false,
+        },
+        customOdds,
+        customProbs: null,
+        viewMode: false,
+        useWebDomain: false,
+        tableMode: 'normal',
+      };
+
+      // Build round state with custom odds mode disabled (baseline)
+      const roundStateWithoutCustomOdds: RoundState = {
+        ...roundStateWithCustomOdds,
+        advanced: {
+          ...roundStateWithCustomOdds.advanced,
+          customOddsMode: false,
+        },
+        customOdds: null,
+      };
+
+      // Build simple bets
+      const bets: Bet = new Map<number, number[]>();
+      const betAmounts: BetAmount = new Map<number, number>();
+
+      // Add at least one real bet (non-zero pirate indices)
+      bets.set(1, [1, 0, 0, 0, 0]); // Bet on pirate 1 in arena 0
+      betAmounts.set(1, 100);
+
+      // Calculate with custom odds enabled
+      const resultWithCustomOdds = calculateRoundData(roundStateWithCustomOdds, bets, betAmounts);
+
+      // Calculate with custom odds disabled (baseline)
+      const resultWithoutCustomOdds = calculateRoundData(
+        roundStateWithoutCustomOdds,
+        bets,
+        betAmounts,
+      );
+
+      // Odds/Payoff/E.R./N.E./Maxbet must reflect the resolved custom odds
+      // (this is the part of the original bug report that already worked;
+      // kept here as a regression guard alongside the probabilities check
+      // below).
+      expect(resultWithCustomOdds.odds).toEqual(customOdds);
+      expect(resultWithCustomOdds.betOdds.get(1)).not.toBe(resultWithoutCustomOdds.betOdds.get(1));
+      expect(resultWithCustomOdds.betPayoffs.get(1)).not.toBe(
+        resultWithoutCustomOdds.betPayoffs.get(1),
+      );
+
+      // legacyProbabilities/logitProbabilities are still computed from the
+      // patched `effectiveRoundData` (verifying calculateRoundData no longer
+      // silently ignores the resolved odds when building that payload).
+      // NOTE: as of the currently vendored wasm engine, neither probability
+      // model actually varies its output based on currentOdds/customOdds -
+      // OriginalModel derives "std"/"used" purely from openingOdds
+      // (wasm/neofoodclub_rs/crates/core/src/models/original.rs), and
+      // MultinomialLogitModel derives it purely from food-adjustment data
+      // (.../models/multinomial_logit.rs). So betProbabilities intentionally
+      // stays identical here unless customProbs is also set - this is
+      // documented, verified wasm-engine behavior, not a gap in this fix.
+      expect(resultWithCustomOdds.legacyProbabilities.used).toEqual(
+        resultWithoutCustomOdds.legacyProbabilities.used,
+      );
     });
   });
 });

--- a/src/app/components/tables/ArenaTableBody.tsx
+++ b/src/app/components/tables/ArenaTableBody.tsx
@@ -44,6 +44,7 @@ import {
   useStableLegacyProbabilityStd,
   useStablePirateFA,
   useCustomOddsMode,
+  useCustomOddsValue,
   useFaDetails,
   useSwapPiratesForAllBets,
   useBetStore,
@@ -407,9 +408,14 @@ const PirateRow = React.memo(
     const legacyProbStd = useStableLegacyProbabilityStd(arenaId, pirateIndex + 1);
     const pirateFA = useStablePirateFA(arenaId, pirateIndex);
     const customOddsMode = useCustomOddsMode();
+    const customOddsValue = useCustomOddsValue(arenaId, pirateIndex + 1);
     const getPirateBgColor = useGetPirateBgColor();
     const faDetails = useFaDetails();
-    const useOdds = currentOdds;
+    // Payout should reflect Custom Odds when active, matching how the bet-level
+    // Odds/Payoff columns already resolve odds (see getOdds() in util.ts) -
+    // otherwise this cell silently ignores a pirate's edited custom odds value.
+    const useOdds =
+      bigBrain && customOddsMode && customOddsValue !== undefined ? customOddsValue : currentOdds;
     const payout = useOdds! * prob - 1;
 
     const payoutBackground = useMemo(() => {

--- a/src/app/hooks/useProbabilities.ts
+++ b/src/app/hooks/useProbabilities.ts
@@ -1,7 +1,9 @@
 import { useMemo } from 'react';
 
+import type { RoundState } from '../../types';
 import { computeLegacyProbabilities, computeLogitProbabilities } from '../maths';
 import { useRoundStore } from '../stores';
+import { getOdds } from '../util';
 
 /**
  * Hook that computes both legacy and logit probabilities
@@ -12,20 +14,53 @@ export function useProbabilities(): {
   logitProbabilities: number[][];
 } {
   const roundData = useRoundStore(state => state.roundData);
+  const customOdds = useRoundStore(state => state.customOdds);
+  const bigBrain = useRoundStore(state => state.bigBrain);
+  const customOddsMode = useRoundStore(state => state.customOddsMode);
+
+  // Compute effective odds using getOdds, which respects customOddsMode and bigBrain
+  const effectiveOdds = useMemo(() => {
+    if (!roundData) {
+      return [];
+    }
+    const partialRoundState: Partial<RoundState> = {
+      roundData,
+      customOdds,
+      advanced: {
+        bigBrain,
+        customOddsMode,
+        oddsTimeline: false,
+        faDetails: false,
+        useLogitModel: false,
+      },
+    };
+    return getOdds(partialRoundState);
+  }, [roundData, customOdds, bigBrain, customOddsMode]);
+
+  // Build effectiveRoundData with custom odds applied if needed
+  const effectiveRoundData = useMemo(() => {
+    if (!roundData || !effectiveOdds.length) {
+      return roundData;
+    }
+    if (effectiveOdds !== roundData.currentOdds) {
+      return { ...roundData, currentOdds: effectiveOdds };
+    }
+    return roundData;
+  }, [roundData, effectiveOdds]);
 
   const legacyProbabilities = useMemo(() => {
-    if (!roundData) {
+    if (!effectiveRoundData) {
       return [];
     }
-    return computeLegacyProbabilities(roundData).used;
-  }, [roundData]);
+    return computeLegacyProbabilities(effectiveRoundData).used;
+  }, [effectiveRoundData]);
 
   const logitProbabilities = useMemo(() => {
-    if (!roundData) {
+    if (!effectiveRoundData) {
       return [];
     }
-    return computeLogitProbabilities(roundData).used;
-  }, [roundData]);
+    return computeLogitProbabilities(effectiveRoundData).used;
+  }, [effectiveRoundData]);
 
   return {
     legacyProbabilities,

--- a/src/app/util.ts
+++ b/src/app/util.ts
@@ -279,6 +279,17 @@ export function getOddsTimelineMode(): boolean {
   return getBooleanCookie('oddsTimelineMode');
 }
 
+export function getOdds(roundState?: RoundState | Partial<RoundState>): OddsData {
+  // the odds we will use for things.
+  // basically this just checks if the custom mode is on or not, and grabs the proper one.
+  // returns the current round odds if there are no custom odds
+  const odds = roundState?.roundData?.currentOdds ?? [];
+  if (roundState?.advanced?.bigBrain && roundState?.advanced?.customOddsMode) {
+    return roundState?.customOdds ?? odds;
+  }
+  return odds;
+}
+
 export function getUseWebDomain(): boolean {
   return getBooleanCookie('useWebDomain');
 }
@@ -418,17 +429,6 @@ export function sortedIndices(arr: number[]): number[] {
     .map(obj => obj.ind);
 }
 
-function getOdds(roundState?: RoundState | Partial<RoundState>): OddsData {
-  // the odds we will use for things.
-  // basically this just checks if the custom mode is on or not, and grabs the proper one.
-  // returns the current round odds if there are no custom odds
-  const odds = roundState?.roundData?.currentOdds ?? [];
-  if (roundState?.advanced?.bigBrain && roundState?.advanced?.customOddsMode) {
-    return roundState?.customOdds ?? odds;
-  }
-  return odds;
-}
-
 function getProbs(
   roundState: RoundState,
   legacyProbs: ProbabilityData,
@@ -546,8 +546,12 @@ export function calculateRoundData(
   const odds = getOdds(roundState);
   if (isValidRound(roundState) && odds && bets && betAmounts) {
     if (roundState && roundState.roundData) {
-      legacyProbabilities = computeLegacyProbabilities(roundState.roundData);
-      logitProbabilities = computeLogitProbabilities(roundState.roundData);
+      const effectiveRoundData =
+        odds !== roundState.roundData.currentOdds
+          ? { ...roundState.roundData, currentOdds: odds }
+          : roundState.roundData;
+      legacyProbabilities = computeLegacyProbabilities(effectiveRoundData);
+      logitProbabilities = computeLogitProbabilities(effectiveRoundData);
       usedProbabilities = getProbs(roundState, legacyProbabilities, logitProbabilities);
 
       pirateFAs = computePirateFAs(roundState.roundData);


### PR DESCRIPTION
## Summary
- The actual bug: the per-pirate "Payout" cell in the Big Brain table (`ArenaTableBody.tsx`, odds x probability - 1, shown as a %) read the real current odds directly and never checked Custom Odds mode at all. Editing a pirate's Custom Odds value had zero effect on this cell. Fixed to resolve the same way the bet-level Odds/Payoff columns already do: use the custom value when Big Brain + Custom Odds mode are active and one is set for that pirate. Covered by a new test that fails on the old code and passes with the fix, asserting the displayed value equals `customOdds * probability - 1` exactly.
- Also included (first commit): while investigating, found that the bet-level "Prob." percentage column (a separate, different column) has never responded to Custom Odds at any point in this project's history (checked the 2021 original, the pre-wasm JS port, and today's Rust engine - all three derive probability from openingOdds/food data only). That's working as designed, not a bug. That commit just makes odds resolution consistent between `calculateRoundData` and the previously-inconsistent `useProbabilities` hook (used by `AllBetsModal`), with a test documenting the intentional no-op on probabilities.