### PR TITLE
Fix pirate name cell rendering darker than rest of winning row

### DIFF
--- a/src/app/components/tables/ArenaTableBody.tsx
+++ b/src/app/components/tables/ArenaTableBody.tsx
@@ -712,8 +712,8 @@ const PirateRow = React.memo(
         backgroundColor={pirateWon ? 'nfc-green.subtle' : 'transparent'}
       >
         <StickyTd
-          layerStyle="fill.muted"
-          colorPalette={getPirateBgColor(openingOdds!)}
+          layerStyle={pirateWon ? 'fill.subtle' : 'fill.muted'}
+          colorPalette={pirateWon ? 'nfc-green' : getPirateBgColor(openingOdds!)}
           onClick={handleTimelineClickLocal}
           cursor="pointer"
           title={`Click to view odds timeline for ${fullPirateName}`}

--- a/src/app/components/tables/DropDownTable.tsx
+++ b/src/app/components/tables/DropDownTable.tsx
@@ -133,8 +133,8 @@ const PirateInfoRow = React.memo(
           onClick={onClick}
           cursor="pointer"
           title={`Click to view odds timeline for ${fullPirateName}`}
-          layerStyle="fill.muted"
-          colorPalette={getPirateBgColor(opening)}
+          layerStyle={didPirateWin ? 'fill.subtle' : 'fill.muted'}
+          colorPalette={didPirateWin ? 'nfc-green' : getPirateBgColor(opening)}
         >
           {pirateName}
         </Td>


### PR DESCRIPTION
The pirate-name cell always used fill.muted with an odds-tier color, independent of win state, while sibling cells switch to fill.subtle + nfc-green when the pirate won. These used to resolve to the same flat color, but the muted token was given its own darker shade in #915 for button hover states, exposing the mismatch whenever a winner's odds tier landed in the green bucket.