### PR TITLE
Cache the wasm-pack build via R2, keyed on submodule SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
       run: bun install --frozen-lockfile
 
     - name: Build wasm math core
+      env:
+        WASM_CACHE_UPLOAD_TOKEN: ${{ secrets.CF_R2_WASM_CACHE_TOKEN }}
       run: bun run build:wasm
 
     - name: Lint & Type Check

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -5,6 +5,24 @@
 # CI already have wasm-pack installed and skip straight to the build.
 set -e
 
+WASM_SHA=$(git -C wasm/neofoodclub_rs rev-parse HEAD)
+PKG_DIR=wasm/pkg
+CACHE_URL="https://pub-fe0294c3912c4425b7e998411ef6e975.r2.dev/wasm-pkg-$WASM_SHA.tar.gz"
+
+if [ -f "$PKG_DIR/.build-sha" ] && [ "$(cat "$PKG_DIR/.build-sha")" = "$WASM_SHA" ] && [ -f "$PKG_DIR/neofoodclub_wasm_bg.wasm" ]; then
+  echo "wasm/pkg already built for $WASM_SHA, skipping"
+  exit 0
+fi
+
+rm -rf "$PKG_DIR" && mkdir -p "$PKG_DIR"
+if curl -fsSL -o /tmp/wasm-pkg-cache.tar.gz "$CACHE_URL"; then
+  tar -xzf /tmp/wasm-pkg-cache.tar.gz -C "$PKG_DIR"
+  echo "$WASM_SHA" > "$PKG_DIR/.build-sha"
+  echo "Restored prebuilt wasm/pkg for $WASM_SHA from cache"
+  exit 0
+fi
+echo "No cached wasm build found for $WASM_SHA, compiling from source"
+
 if ! command -v wasm-pack >/dev/null 2>&1; then
   export RUSTUP_HOME="${RUSTUP_HOME:-/tmp/rustup}"
   export CARGO_HOME="${CARGO_HOME:-/tmp/cargo}"
@@ -19,3 +37,9 @@ if ! command -v wasm-pack >/dev/null 2>&1; then
 fi
 
 wasm-pack build wasm/neofoodclub_rs/crates/wasm --target bundler --out-dir ../../../pkg --out-name neofoodclub_wasm
+echo "$WASM_SHA" > "$PKG_DIR/.build-sha"
+
+if [ -n "$WASM_CACHE_UPLOAD_TOKEN" ]; then
+  tar -czf /tmp/wasm-pkg-cache.tar.gz -C "$PKG_DIR" .
+  CLOUDFLARE_API_TOKEN="$WASM_CACHE_UPLOAD_TOKEN" npx wrangler r2 object put "neofoodclub-wasm-cache/wasm-pkg-$WASM_SHA.tar.gz" --file /tmp/wasm-pkg-cache.tar.gz --remote || echo "warning: failed to publish wasm cache to R2 (non-fatal)"
+fi


### PR DESCRIPTION
## Summary
- scripts/build-wasm.sh now skips the wasm-pack build entirely when possible: a local `.build-sha` marker gives an instant skip when the wasm submodule commit is unchanged, and otherwise it tries fetching a prebuilt `wasm/pkg` tarball from a public Cloudflare R2 bucket keyed on that commit SHA before falling back to a normal compile
- ci.yml's "Build wasm math core" step now passes `WASM_CACHE_UPLOAD_TOKEN` (from the `CF_R2_WASM_CACHE_TOKEN` repo secret) so a fresh compile gets published back to R2 for other jobs/environments to reuse
- Fetch and publish failures always fall through to a normal compile rather than breaking the build - verified locally with an invalid token (non-fatal warning, script still exits 0)

## Why
The wasm-pack build (release profile + wasm-opt) previously ran unconditionally on every start/build/test, costing ~60-90s every time. Worst case is Cloudflare Pages, which reinstalls the entire Rust toolchain from scratch on every single build since /tmp isn't persisted there, and Cloudflare's own build-caching feature can't cache a custom toolchain/target dir. The wasm submodule pin only actually changes in ~3.5% of commits, so a SHA-keyed cache hits almost every time.

## Verification
- Local marker fast-path: rebuilding with an unchanged submodule SHA skips in ~25ms instead of ~90s
- R2 fetch-miss -> compile fallback: confirmed via a 404 on an unpublished SHA
- R2 fetch-hit: published the real artifact, then confirmed a clean `rm -rf wasm/pkg` run restores it from R2 instead of compiling
- `bun run test:coverage` (428/428) and `bun run build` both pass against the R2-fetched artifact
- Invalid upload token produces a non-fatal warning and the script still exits 0