### PR TITLE
Update react and react-dom to v19.2.8

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "next-themes": "^0.4.6",
         "react": "19.2.8",
         "react-chartjs-2": "^5.3.0",
-        "react-dom": "19.2.7",
+        "react-dom": "19.2.8",
         "react-icons": "^5.5.0",
         "react-scan": "^0.5.0",
         "react-window": "^2.2.1",
@@ -1734,7 +1734,7 @@
 
     "react-doctor": ["react-doctor@0.8.3", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@sentry/node": "^10.54.0", "agent-install": "0.0.5", "conf": "^15.1.0", "confbox": "^0.2.4", "deslop-js": "0.8.3", "eslint-plugin-react-hooks": "^7.1.1", "jiti": "^2.7.0", "magicast": "^0.5.3", "oxlint": ">=1.66.0 <1.67.0", "oxlint-plugin-react-doctor": "0.8.3", "prompts": "^2.4.2", "typescript": ">=5.0.4 <6", "vscode-languageserver": "^9.0.1", "vscode-languageserver-textdocument": "^1.0.12", "vscode-uri": "^3.1.0", "yaml": "^2.9.0" }, "bin": { "react-doctor": "bin/react-doctor.js" } }, "sha512-FfG7YQKb1yv1UNk2gknZzLAPx6L3RMOhYsYbslr4MSpVMNk5xBHlu9VxjtS0br0DEBWjkZovrf/C1MrchiIzAw=="],
 
-    "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+    "react-dom": ["react-dom@19.2.8", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.8" } }, "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ=="],
 
     "react-grab": ["react-grab@0.1.48", "", { "dependencies": { "@react-grab/cli": "0.1.48", "bippy": "^0.5.43" }, "peerDependencies": { "react": ">=17.0.0" }, "optionalPeers": ["react"], "bin": { "react-grab": "bin/cli.js" } }, "sha512-p3WnmK9LLvXE/c4ITPLlXcP1fkXo2VFEQqK94tIfcHIWKNdqdhYYFyNVioO50HR+uyHIwT63Z4txZDqJlVcD/Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "next-themes": "^0.4.6",
-        "react": "19.2.7",
+        "react": "19.2.8",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "19.2.7",
         "react-icons": "^5.5.0",
@@ -1728,7 +1728,7 @@
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
-    "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+    "react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
 
     "react-chartjs-2": ["react-chartjs-2@5.3.1", "", { "peerDependencies": { "chart.js": "^4.1.1", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-h5IPXKg9EXpjoBzUfyWJvllMjG2mQ4EiuHQFhms/AjUm0XSZHhyRy2xVmLXHKrtcdrPO4mnGqRtYoD0vp95A0A=="],
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "next-themes": "^0.4.6",
     "react": "19.2.8",
     "react-chartjs-2": "^5.3.0",
-    "react-dom": "19.2.7",
+    "react-dom": "19.2.8",
     "react-icons": "^5.5.0",
     "react-scan": "^0.5.0",
     "react-window": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "next-themes": "^0.4.6",
-    "react": "19.2.7",
+    "react": "19.2.8",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "19.2.7",
     "react-icons": "^5.5.0",


### PR DESCRIPTION
Combines #955 and #956 since react and react-dom need to be bumped together (react-dom's peerDependency on react is pinned to the exact version).