### PR TITLE
Mobile UX polish

### DIFF
--- a/e2e/mobile.spec.ts
+++ b/e2e/mobile.spec.ts
@@ -1,0 +1,181 @@
+import { test, expect, Page } from '@playwright/test';
+
+import { setupLocalDataMock } from './test-helpers/local-data-mock';
+
+const MOBILE_VIEWPORT = { width: 375, height: 667 };
+const DESKTOP_VIEWPORT = { width: 1280, height: 800 };
+// Generous tolerance for scrollbar gutters / sub-pixel rounding when comparing
+// scrollWidth vs clientWidth to decide whether an element has "real" overflow.
+const OVERFLOW_TOLERANCE_PX = 24;
+
+async function waitForBettingReady(page: Page): Promise<void> {
+  await page.waitForSelector('#root', { timeout: 30000 });
+  await page.waitForSelector('table', { timeout: 20000 });
+}
+
+// The dev-mode drawer (which hosts the "View All Possible Bets" / "View Round
+// JSON" triggers) normally requires 5 clicks on the footer logo, unless it has
+// been opened before - which we simulate by pre-seeding localStorage so tests
+// only need a single click.
+async function openDevModeDrawer(page: Page): Promise<void> {
+  await page.getByTestId('footer-logo').click();
+  await expect(page.getByRole('heading', { name: 'Dev Mode' })).toBeVisible({ timeout: 10000 });
+}
+
+test.describe('Mobile UX', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem('devModeOpened', 'true');
+    });
+  });
+
+  test('AllBetsModal results table is horizontally scrollable on mobile viewport', async ({
+    page,
+  }) => {
+    await setupLocalDataMock(page);
+    await page.setViewportSize(MOBILE_VIEWPORT);
+    await page.goto('/');
+
+    try {
+      await waitForBettingReady(page);
+    } catch {
+      test.skip(true, 'App failed to load');
+    }
+
+    await openDevModeDrawer(page);
+    await page.getByRole('button', { name: 'View All Possible Bets' }).click();
+
+    await expect(page.getByText(/All Possible Bets \(/)).toBeVisible({ timeout: 10000 });
+
+    const scrollContainer = page.getByTestId('all-bets-scroll-container');
+    await expect(scrollContainer).toBeVisible();
+
+    const { scrollWidth, clientWidth } = await scrollContainer.evaluate(el => ({
+      scrollWidth: el.scrollWidth,
+      clientWidth: el.clientWidth,
+    }));
+
+    // The results table's fixed-width columns are wider than a phone screen by
+    // design - the container must offer real horizontal scroll room rather
+    // than clipping the extra content (the bug this test guards against).
+    expect(scrollWidth).toBeGreaterThan(clientWidth);
+  });
+
+  test('RoundJsonModal has no horizontal overflow on mobile viewport', async ({ page }) => {
+    await setupLocalDataMock(page);
+    await page.setViewportSize(MOBILE_VIEWPORT);
+    await page.goto('/');
+
+    try {
+      await waitForBettingReady(page);
+    } catch {
+      test.skip(true, 'App failed to load');
+    }
+
+    await openDevModeDrawer(page);
+    await page.getByRole('button', { name: 'View Round JSON' }).click();
+
+    const jsonDialog = page.getByRole('dialog').filter({ hasText: /\.json/ });
+    await expect(jsonDialog).toBeVisible({ timeout: 10000 });
+
+    const { scrollWidth, clientWidth } = await jsonDialog.evaluate(el => ({
+      scrollWidth: el.scrollWidth,
+      clientWidth: el.clientWidth,
+    }));
+
+    expect(scrollWidth).toBeLessThanOrEqual(clientWidth + OVERFLOW_TOLERANCE_PX);
+  });
+
+  test('Timeline drawer has no horizontal overflow on mobile viewport', async ({ page }) => {
+    await setupLocalDataMock(page);
+    await page.setViewportSize(MOBILE_VIEWPORT);
+    await page.goto('/');
+
+    try {
+      await waitForBettingReady(page);
+    } catch {
+      test.skip(true, 'App failed to load');
+    }
+
+    // The arena-name cell also carries a similarly-worded title (e.g. "...for
+    // Shipwreck") and spans multiple rows via rowspan - exclude it so this
+    // matches a specific pirate's cell, not the arena header.
+    const pirateCell = page
+      .locator('td[title*="Click to view odds timeline"]:not([rowspan])')
+      .first();
+    await pirateCell.waitFor({ state: 'visible', timeout: 20000 });
+    await pirateCell.click();
+
+    // Clicking a specific pirate's cell opens the drawer scoped to that
+    // pirate (heading is just its name, not "All Odds Changes"), and no other
+    // dialog is open at this point, so a plain role match is unambiguous.
+    const timelineDrawer = page.getByRole('dialog');
+    await expect(timelineDrawer).toBeVisible({ timeout: 10000 });
+
+    const { scrollWidth, clientWidth } = await timelineDrawer.evaluate(el => ({
+      scrollWidth: el.scrollWidth,
+      clientWidth: el.clientWidth,
+    }));
+
+    expect(scrollWidth).toBeLessThanOrEqual(clientWidth + OVERFLOW_TOLERANCE_PX);
+  });
+
+  test('drag-drop tip banner does not render on mobile viewport even when otherwise eligible', async ({
+    browser,
+  }) => {
+    // The banner only appears once this tab has bets AND another open tab has
+    // been seen with bets (cross-tab BroadcastChannel signal) - simulate that
+    // with two pages in the same browser context. newContext() inherits the
+    // running project's default device options (viewport/isMobile/etc.), so
+    // explicitly force a desktop-sized context here - otherwise, under the
+    // Mobile Chrome/Safari projects, this "desktop" page would also be mobile
+    // sized and the sanity check below would never see the banner at all.
+    const context = await browser.newContext({
+      viewport: DESKTOP_VIEWPORT,
+      isMobile: false,
+      hasTouch: false,
+    });
+    const desktopPage = await context.newPage();
+    const mobilePage = await context.newPage();
+
+    try {
+      await setupLocalDataMock(desktopPage);
+      await setupLocalDataMock(mobilePage);
+
+      await desktopPage.goto('/');
+      await mobilePage.setViewportSize(MOBILE_VIEWPORT);
+      await mobilePage.goto('/');
+
+      try {
+        await waitForBettingReady(desktopPage);
+        await waitForBettingReady(mobilePage);
+      } catch {
+        test.skip(true, 'App failed to load');
+      }
+
+      // Each arena's header row also carries a similarly-worded title (see
+      // the pirateCell comment above) and its radios are already checked by
+      // default (meaning "no pirate selected"), so a plain title match would
+      // click a no-op radio - exclude rowspan cells to land on a real pirate row.
+      const pirateRowSelector = 'tr:has(td[title*="Click to view odds timeline"]:not([rowspan]))';
+      const desktopRadio = desktopPage
+        .locator(pirateRowSelector)
+        .first()
+        .getByRole('radio')
+        .first();
+      const mobileRadio = mobilePage.locator(pirateRowSelector).first().getByRole('radio').first();
+
+      await desktopRadio.click({ force: true });
+      await mobileRadio.click({ force: true });
+
+      // Sanity check: on a desktop-sized tab, with both conditions met, the
+      // banner should actually appear - otherwise this test would trivially
+      // pass without the mobile gating being exercised at all.
+      await expect(desktopPage.getByText(/drag a bet link/i)).toBeVisible({ timeout: 15000 });
+
+      await expect(mobilePage.getByText(/drag a bet link/i)).not.toBeVisible();
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/src/app/Footer.tsx
+++ b/src/app/Footer.tsx
@@ -285,7 +285,12 @@ const Footer: React.FC<FooterProps> = props => {
         <Box py={10}>
           <HStack>
             <Separator flex="1" />
-            <Box onClick={handleLogoClick} cursor="pointer" userSelect="none">
+            <Box
+              onClick={handleLogoClick}
+              cursor="pointer"
+              userSelect="none"
+              data-testid="footer-logo"
+            >
               <Logo rotation={rotation} />
             </Box>
             <Separator flex="1" />

--- a/src/app/Header.tsx
+++ b/src/app/Header.tsx
@@ -16,7 +16,6 @@ import {
   AbsoluteCenter,
   Group,
   NumberInputControl,
-  useBreakpointValue,
 } from '@chakra-ui/react';
 import { addYears, differenceInMilliseconds } from 'date-fns';
 import React, { useEffect, useState, useMemo, useCallback, useRef } from 'react';
@@ -28,6 +27,7 @@ import DateFormatter from './components/format/DateFormatter';
 import RoundInput from './components/inputs/RoundInput';
 import GlowCard from './components/ui/GlowCard';
 import { BET_AMOUNT_DEFAULT, BET_AMOUNT_MAX, BET_AMOUNT_MIN } from './constants';
+import { useIsMobile } from './hooks/useIsMobile';
 import { useIsRoundOver } from './hooks/useIsRoundOver';
 import { useRoundProgress } from './hooks/useRoundProgress';
 import NeopointIcon from './images/np-icon.svg';
@@ -621,8 +621,7 @@ const Header: React.FC<HeaderProps> = props => {
   const [y, setY] = useState<number>(0);
   const [hidden, setHidden] = useState(false);
   const lastY = useRef(0);
-  const isMobile =
-    useBreakpointValue({ base: true, md: false }, { fallback: 'base', ssr: false }) ?? false;
+  const isMobile = useIsMobile();
 
   useEffect(() => {
     const handleScroll = (): void => {

--- a/src/app/Header.tsx
+++ b/src/app/Header.tsx
@@ -51,6 +51,7 @@ interface GoToCurrentRoundButtonProps {
 const GoToCurrentRoundButton: React.FC<GoToCurrentRoundButtonProps> = React.memo(
   ({ testId = 'go-to-current-round' }) => {
     const fetchCurrentRound = useRoundStore(state => state.fetchCurrentRound);
+    const isMobile = useIsMobile();
 
     const handleGoToCurrent = useCallback(async () => {
       await fetchCurrentRound();
@@ -63,14 +64,14 @@ const GoToCurrentRoundButton: React.FC<GoToCurrentRoundButtonProps> = React.memo
     return (
       <Tooltip content="Go to current round" placement="top">
         <Button
-          size="xs"
+          size={isMobile ? 'sm' : 'xs'}
           variant="ghost"
           colorPalette="gray"
           onClick={handleGoToCurrent}
           fontSize="xs"
           height="auto"
           minH="auto"
-          p={1}
+          p={isMobile ? 2 : 1}
           data-testid={testId}
         >
           <FaPlay style={{ fontSize: '12px' }} />
@@ -265,6 +266,7 @@ const RoundInfo: React.FC<RoundInfoProps> = React.memo(({ display = 'block' }: R
 const MaxBetInput: React.FC = () => {
   const currentSelectedRound = useRoundStore(state => state.currentSelectedRound);
   const setMaxBet = useSetMaxBet();
+  const isMobile = useIsMobile();
   const [tempValue, setTempValue] = useState<string>(() =>
     getMaxBet(currentSelectedRound).toString(),
   );
@@ -417,7 +419,7 @@ const MaxBetInput: React.FC = () => {
       </Text>
       <NumberInputRoot
         data-testid="max-bet-input-field"
-        size="xs"
+        size={isMobile ? 'sm' : 'xs'}
         value={tempValue}
         onValueChange={handleChange}
         min={BET_AMOUNT_DEFAULT}
@@ -463,6 +465,7 @@ const MaxBetInput: React.FC = () => {
           isLocked={isLocked}
           onToggle={handleLockToggle}
           maxBet={parseInt(tempValue)}
+          size={isMobile ? 'sm' : '2xs'}
         />
       </Box>
     </Group>

--- a/src/app/Header.tsx
+++ b/src/app/Header.tsx
@@ -468,7 +468,7 @@ const MaxBetInput: React.FC = () => {
           isLocked={isLocked}
           onToggle={handleLockToggle}
           maxBet={parseInt(tempValue)}
-          size={isMobile ? 'sm' : 'xs'}
+          size="2xs"
         />
       </Box>
     </Group>

--- a/src/app/Header.tsx
+++ b/src/app/Header.tsx
@@ -410,6 +410,7 @@ const MaxBetInput: React.FC = () => {
         roundedStart="md"
         roundedEnd={0}
         px="2"
+        height={isMobile ? '9' : '8'}
         display="flex"
         alignItems="center"
         whiteSpace="nowrap"

--- a/src/app/Header.tsx
+++ b/src/app/Header.tsx
@@ -465,7 +465,7 @@ const MaxBetInput: React.FC = () => {
           isLocked={isLocked}
           onToggle={handleLockToggle}
           maxBet={parseInt(tempValue)}
-          size={isMobile ? 'sm' : '2xs'}
+          size={isMobile ? 'sm' : 'xs'}
         />
       </Box>
     </Group>

--- a/src/app/Header.tsx
+++ b/src/app/Header.tsx
@@ -420,6 +420,8 @@ const MaxBetInput: React.FC = () => {
       <NumberInputRoot
         data-testid="max-bet-input-field"
         size={isMobile ? 'sm' : 'xs'}
+        height={isMobile ? '9' : '8'}
+        overflow="hidden"
         value={tempValue}
         onValueChange={handleChange}
         min={BET_AMOUNT_DEFAULT}

--- a/src/app/__tests__/DragDropTipBanner.test.tsx
+++ b/src/app/__tests__/DragDropTipBanner.test.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { render } from '../../test/utils';
 import DragDropTipBanner from '../components/DragDropTipBanner';
-import { useOtherTabHasBets } from '../hooks';
+import { useIsMobile, useOtherTabHasBets } from '../hooks';
 import { useHasAnyBets } from '../stores';
 
 vi.mock('../stores', () => ({
@@ -12,10 +12,12 @@ vi.mock('../stores', () => ({
 
 vi.mock('../hooks', () => ({
   useOtherTabHasBets: vi.fn(),
+  useIsMobile: vi.fn(),
 }));
 
 const mockUseHasAnyBets = vi.mocked(useHasAnyBets);
 const mockUseOtherTabHasBets = vi.mocked(useOtherTabHasBets);
+const mockUseIsMobile = vi.mocked(useIsMobile);
 
 /** In-memory localStorage stand-in, since jsdom's real implementation is
  * unreliable across Node versions/environments in this test setup. */
@@ -42,6 +44,7 @@ function createMockLocalStorage(): Storage {
 describe('DragDropTipBanner', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseIsMobile.mockReturnValue(false);
     Object.defineProperty(window, 'localStorage', {
       value: createMockLocalStorage(),
       writable: true,
@@ -74,6 +77,16 @@ describe('DragDropTipBanner', () => {
     render(<DragDropTipBanner />);
 
     expect(screen.getByText(/drag a bet link/i)).toBeInTheDocument();
+  });
+
+  it('renders nothing on mobile viewports even if anyBets and otherTabHasBets are true', () => {
+    mockUseHasAnyBets.mockReturnValue(true);
+    mockUseOtherTabHasBets.mockReturnValue(true);
+    mockUseIsMobile.mockReturnValue(true);
+
+    render(<DragDropTipBanner />);
+
+    expect(screen.queryByText(/drag a bet link/i)).not.toBeInTheDocument();
   });
 
   it('hides the banner when the close button is clicked', () => {

--- a/src/app/components/DragDropTipBanner.tsx
+++ b/src/app/components/DragDropTipBanner.tsx
@@ -2,7 +2,7 @@ import { Box, CloseButton, Flex, Text } from '@chakra-ui/react';
 import React, { useState } from 'react';
 import { FaLightbulb } from 'react-icons/fa6';
 
-import { useOtherTabHasBets } from '../hooks';
+import { useIsMobile, useOtherTabHasBets } from '../hooks';
 import { useHasAnyBets } from '../stores';
 
 const DISMISSED_STORAGE_KEY = 'dragDropTipDismissed';
@@ -13,9 +13,10 @@ const readDismissed = (): boolean =>
 export default React.memo(function DragDropTipBanner(): React.ReactElement | null {
   const anyBets = useHasAnyBets();
   const otherTabHasBets = useOtherTabHasBets();
+  const isMobile = useIsMobile();
   const [dismissed, setDismissed] = useState(readDismissed);
 
-  if (!anyBets || !otherTabHasBets || dismissed) {
+  if (!anyBets || !otherTabHasBets || dismissed || isMobile) {
     return null;
   }
 

--- a/src/app/components/bets/MaxBetLockToggle.tsx
+++ b/src/app/components/bets/MaxBetLockToggle.tsx
@@ -10,29 +10,32 @@ interface MaxBetLockToggleProps {
   isLocked: boolean;
   onToggle: (locked: boolean) => void;
   maxBet: number;
+  size?: '2xs' | 'xs' | 'sm';
 }
 
-const MaxBetLockToggle = memo(({ isLocked: locked, onToggle, maxBet }: MaxBetLockToggleProps) => {
-  const tooltipLabel = locked
-    ? 'Max bet is locked - will not increase with round number'
-    : maxBet === BET_AMOUNT_DEFAULT
-      ? 'Max bet is unlocked'
-      : 'Max bet is unlocked - will increase by 2 per round';
+const MaxBetLockToggle = memo(
+  ({ isLocked: locked, onToggle, maxBet, size = '2xs' }: MaxBetLockToggleProps) => {
+    const tooltipLabel = locked
+      ? 'Max bet is locked - will not increase with round number'
+      : maxBet === BET_AMOUNT_DEFAULT
+        ? 'Max bet is unlocked'
+        : 'Max bet is unlocked - will increase by 2 per round';
 
-  return (
-    <Tooltip content={tooltipLabel} showArrow placement="top" openDelay={600} paddingInline={0}>
-      <IconButton
-        size="2xs"
-        variant="ghost"
-        onClick={() => onToggle(!locked)}
-        data-testid="max-bet-lock-toggle"
-        pointerEvents="auto"
-      >
-        {locked ? <FaLock /> : <FaLockOpen />}
-      </IconButton>
-    </Tooltip>
-  );
-});
+    return (
+      <Tooltip content={tooltipLabel} showArrow placement="top" openDelay={600} paddingInline={0}>
+        <IconButton
+          size={size}
+          variant="ghost"
+          onClick={() => onToggle(!locked)}
+          data-testid="max-bet-lock-toggle"
+          pointerEvents="auto"
+        >
+          {locked ? <FaLock /> : <FaLockOpen />}
+        </IconButton>
+      </Tooltip>
+    );
+  },
+);
 
 MaxBetLockToggle.displayName = 'MaxBetLockToggle';
 

--- a/src/app/components/modals/AllBetsModal.tsx
+++ b/src/app/components/modals/AllBetsModal.tsx
@@ -374,7 +374,7 @@ export const AllBetsModal: React.FC<AllBetsModalProps> = React.memo(({ isOpen, o
                 <CloseButton size="sm" />
               </Dialog.CloseTrigger>
             </Dialog.Header>
-            <Dialog.Body display="flex" flexDirection="column" overflow="hidden">
+            <Dialog.Body display="flex" flexDirection="column" overflowX="hidden" overflowY="auto">
               <Stack gap={4} flex={1} minHeight={0}>
                 <Text fontSize="sm" color="fg.muted" flexShrink={0}>
                   Note: Settings changed here will not affect your saved settings.
@@ -660,9 +660,15 @@ export const AllBetsModal: React.FC<AllBetsModalProps> = React.memo(({ isOpen, o
                   </Box>
                 </Stack>
 
-                <Box flex={1} minHeight={0} display="flex" flexDirection="column">
+                <Box
+                  flex={1}
+                  minHeight={{ base: '320px', md: 0 }}
+                  display="flex"
+                  flexDirection="column"
+                >
                   {/* Header + List wrapper for horizontal scroll */}
                   <Box
+                    data-testid="all-bets-scroll-container"
                     overflowX="auto"
                     flex={1}
                     minHeight={0}

--- a/src/app/components/modals/AllBetsModal.tsx
+++ b/src/app/components/modals/AllBetsModal.tsx
@@ -661,61 +661,78 @@ export const AllBetsModal: React.FC<AllBetsModalProps> = React.memo(({ isOpen, o
                 </Stack>
 
                 <Box flex={1} minHeight={0} display="flex" flexDirection="column">
-                  {/* Header */}
-                  <Box borderBottomWidth="2px" fontWeight="bold" bg="bg.muted" flexShrink={0}>
-                    <HStack px={2} py={2} fontSize="xs" gap={2} flexWrap="nowrap">
-                      <Text width="40px" textAlign="right" flexShrink={0}>
-                        #
-                      </Text>
-                      <Text width="350px" flexShrink={0}>
-                        Pirates
-                      </Text>
-                      <Text width="60px" textAlign="right" flexShrink={0}>
-                        Odds
-                      </Text>
-                      <Text width="80px" textAlign="right" flexShrink={0}>
-                        Payoff
-                      </Text>
-                      <Text width="60px" textAlign="right" flexShrink={0}>
-                        Prob
-                      </Text>
-                      <Text width="60px" textAlign="right" flexShrink={0}>
-                        ER
-                      </Text>
-                      <Text width="80px" textAlign="right" flexShrink={0}>
-                        NE
-                      </Text>
-                      <Text width="80px" textAlign="right" flexShrink={0}>
-                        MaxBet
-                      </Text>
-                      <Text
-                        width={showBinaryAsHex ? '80px' : '130px'}
-                        textAlign="center"
-                        flexShrink={0}
-                      >
-                        Binary
-                      </Text>
-                    </HStack>
-                  </Box>
-
-                  {/* Virtualized List */}
+                  {/* Header + List wrapper for horizontal scroll */}
                   <Box
+                    overflowX="auto"
                     flex={1}
                     minHeight={0}
-                    opacity={isPending ? 0.5 : 1}
-                    transition="opacity 0.2s"
+                    display="flex"
+                    flexDirection="column"
                   >
-                    <List<RowData>
-                      defaultHeight={400}
-                      rowCount={filteredBets.length}
-                      rowHeight={32}
-                      rowComponent={
-                        Row as (
-                          props: { index: number; style: React.CSSProperties } & RowData,
-                        ) => React.ReactElement | null
-                      }
-                      rowProps={itemData as RowData}
-                    />
+                    {/* Header */}
+                    <Box borderBottomWidth="2px" fontWeight="bold" bg="bg.muted" flexShrink={0}>
+                      <HStack
+                        px={2}
+                        py={2}
+                        fontSize="xs"
+                        gap={2}
+                        flexWrap="nowrap"
+                        minWidth="fit-content"
+                      >
+                        <Text width="40px" textAlign="right" flexShrink={0}>
+                          #
+                        </Text>
+                        <Text width="350px" flexShrink={0}>
+                          Pirates
+                        </Text>
+                        <Text width="60px" textAlign="right" flexShrink={0}>
+                          Odds
+                        </Text>
+                        <Text width="80px" textAlign="right" flexShrink={0}>
+                          Payoff
+                        </Text>
+                        <Text width="60px" textAlign="right" flexShrink={0}>
+                          Prob
+                        </Text>
+                        <Text width="60px" textAlign="right" flexShrink={0}>
+                          ER
+                        </Text>
+                        <Text width="80px" textAlign="right" flexShrink={0}>
+                          NE
+                        </Text>
+                        <Text width="80px" textAlign="right" flexShrink={0}>
+                          MaxBet
+                        </Text>
+                        <Text
+                          width={showBinaryAsHex ? '80px' : '130px'}
+                          textAlign="center"
+                          flexShrink={0}
+                        >
+                          Binary
+                        </Text>
+                      </HStack>
+                    </Box>
+
+                    {/* Virtualized List */}
+                    <Box
+                      flex={1}
+                      minHeight={0}
+                      minWidth="fit-content"
+                      opacity={isPending ? 0.5 : 1}
+                      transition="opacity 0.2s"
+                    >
+                      <List<RowData>
+                        defaultHeight={400}
+                        rowCount={filteredBets.length}
+                        rowHeight={32}
+                        rowComponent={
+                          Row as (
+                            props: { index: number; style: React.CSSProperties } & RowData,
+                          ) => React.ReactElement | null
+                        }
+                        rowProps={itemData as RowData}
+                      />
+                    </Box>
                   </Box>
                 </Box>
               </Stack>

--- a/src/app/components/tables/ArenaTableBody.tsx
+++ b/src/app/components/tables/ArenaTableBody.tsx
@@ -24,6 +24,7 @@ import {
   FOODS,
 } from '../../constants';
 import { useGetPirateBgColor } from '../../hooks/useGetPirateBgColor';
+import { useIsMobile } from '../../hooks/useIsMobile';
 import { computePirateBinary, makeEmpty } from '../../maths';
 import {
   usePiratesForArena,
@@ -390,6 +391,7 @@ const PirateRow = React.memo(
     handleTimelineClick: (a: number, p: number) => void;
     handleBetLineChange: (a: number, v: number) => void;
   }) => {
+    const isMobile = useIsMobile();
     const pirateId = usePirateId(arenaId, pirateIndex);
     const openingOdds = useOpeningOddsValue(arenaId, pirateIndex);
     const currentOdds = useCurrentOddsValue(arenaId, pirateIndex);
@@ -753,7 +755,7 @@ const PirateRow = React.memo(
             <Tooltip content="10-bet" openDelay={600} placement="top">
               <IconButton
                 aria-label="10-bet"
-                size="2xs"
+                size={isMobile ? 'sm' : '2xs'}
                 variant="ghost"
                 onClick={handleBetLineChangeLocal}
               >
@@ -778,7 +780,7 @@ const PirateRow = React.memo(
                   >
                     <IconButton
                       aria-label="Swap pirate"
-                      size="2xs"
+                      size={isMobile ? 'sm' : '2xs'}
                       variant="ghost"
                       disabled={!arenaHasAnyChosen}
                     >
@@ -789,7 +791,7 @@ const PirateRow = React.memo(
               </Popover.Trigger>
               <Portal>
                 <Popover.Positioner>
-                  <Popover.Content width="360px">
+                  <Popover.Content width={{ base: 'calc(100vw - 2rem)', md: '360px' }}>
                     <Popover.Arrow />
                     <Popover.Body>
                       <VStack align="center" gap={2}>

--- a/src/app/hooks/index.ts
+++ b/src/app/hooks/index.ts
@@ -7,6 +7,7 @@ export { useDuplicateBets } from './useDuplicateBets';
 export { useFormattedDate } from './useFormattedDate';
 export { useGetPirateBgColor } from './useGetPirateBgColor';
 export { useInterval } from './useInterval';
+export { useIsMobile } from './useIsMobile';
 export { useIsRoundOver } from './useIsRoundOver';
 export { useOtherTabHasBets } from './useOtherTabHasBets';
 export { useProbabilities } from './useProbabilities';

--- a/src/app/hooks/useIsMobile.ts
+++ b/src/app/hooks/useIsMobile.ts
@@ -1,0 +1,5 @@
+import { useBreakpointValue } from '@chakra-ui/react';
+
+export function useIsMobile(): boolean {
+  return useBreakpointValue({ base: true, md: false }, { fallback: 'base', ssr: false }) ?? false;
+}


### PR DESCRIPTION
## Summary
- Extract a shared `useIsMobile()` hook (was duplicated inline in Header.tsx)
- Fix a real bug: the "All Bets" results table was clipped instead of horizontally scrollable on narrow viewports, and could get squeezed to zero height on short viewports (e.g. iPhone SE) by the settings section above it
- Hide the drag-drop tip banner on mobile - it advertises an HTML5 drag-and-drop import flow that doesn't work on mobile touch, but click-to-copy still works fine there
- Enlarge touch targets that were below the ~44px guideline (round-info button, max-bet input group, per-row 10-bet/swap-pirate controls), gated to mobile only so desktop density is unchanged
- Add `e2e/mobile.spec.ts` covering the above, run against the existing Mobile Chrome/Safari Playwright projects

Timeline drawer and RoundJsonModal were audited for the same kind of overflow and found not to need changes.