### PR TITLE
Increase Playwright webServer timeout to tolerate cold wasm builds

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -87,7 +87,11 @@ export default defineConfig({
     command: 'npm start',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env['CI'],
-    timeout: 120000,
+    // `npm start` triggers `build:wasm`, which does a from-scratch Rust/wasm
+    // compile (3-4 min) whenever the R2 build cache misses - e.g. the first
+    // CI run to see a new wasm/neofoodclub_rs submodule commit. 120s isn't
+    // enough to cover that cold-build path, so give it more headroom.
+    timeout: 300000,
     stdout: 'pipe',
     stderr: 'pipe',
     env: {


### PR DESCRIPTION
## Summary
- `scripts/build-wasm.sh` caches the compiled wasm output in R2, keyed by the exact `wasm/neofoodclub_rs` submodule commit SHA
- Any PR that bumps that submodule to a new SHA (e.g. every Renovate digest update, see #982) forces a from-scratch Rust/wasm compile the first time CI encounters it, which takes 3-4 minutes
- The Playwright `webServer.timeout` was 120000ms (2 min), too short for that cold-build path, causing intermittent shard failures/timeouts
- Bumped it to 300000ms (5 min) to give the cold-build path enough headroom while still failing fast on genuine startup problems